### PR TITLE
FISH-7703 Create Payara 6 Version of Diagnostic Tool

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,9 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <payara.version>6.13.0</payara.version>
+
+        <javadoc.skip>true</javadoc.skip>
+        <source.skip>true</source.skip>
     </properties>
 
     <repositories>
@@ -159,6 +162,41 @@
                     </supportedProjectTypes>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.6.3</version>
+                <configuration>
+                    <detectOfflineLinks>false</detectOfflineLinks>
+                    <skip>${javadoc.skip}</skip>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.3.0</version>
+                <configuration>
+                    <includePom>true</includePom>
+                    <skipSource>${source.skip}</skipSource>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
 
         <pluginManagement>
@@ -225,4 +263,51 @@
             </plugins>
         </pluginManagement>
     </build>
+
+    <distributionManagement>
+        <repository>
+            <id>payara-nexus-enterprise-artifacts</id>
+            <name>Payara Nexus Enterprise Artifacts</name>
+            <url>https://nexus.dev.payara.fish/repository/payara-enterprise-artifacts-private</url>
+        </repository>
+        <snapshotRepository>
+            <id>payara-nexus-enterprise-snapshots</id>
+            <name>Payara Nexus Enterprise Snapshots</name>
+            <url>https://nexus.dev.payara.fish/repository/payara-enterprise-snapshots-private</url>
+        </snapshotRepository>
+    </distributionManagement>
+
+    <profiles>
+        <profile>
+            <id>release</id>
+
+            <properties>
+                <javadoc.skip>false</javadoc.skip>
+                <source.skip>false</source.skip>
+                <gpg.skip>false</gpg.skip>
+            </properties>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>3.1.0</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                                <configuration>
+                                    <skip>${gpg.skip}</skip>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
 
     <groupId>fish.payara.extras</groupId>
     <artifactId>payara-diagnostics-tool</artifactId>
-    <version>1.0</version>
+    <version>2.0-SNAPSHOT</version>
     <packaging>glassfish-jar</packaging>
 
     <name>payara-diagnostics-tool</name>
@@ -62,23 +62,38 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
-        <payara.version>5.36.0</payara.version>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <payara.version>6.13.0</payara.version>
     </properties>
 
     <repositories>
         <repository>
-            <id>payara-enterprise</id>
-            <name>Payara Enterprise Private Artifacts</name>
-            <url>https://nexus.dev.payara.fish/repository/payara-enterprise-artifacts-private/</url>
-        </repository>
-        <repository>
-            <id>payara-nexus</id>
+            <id>payara-nexus-artifacts</id>
             <name>Payara Public Artifacts</name>
             <url>https://nexus.dev.payara.fish/repository/payara-artifacts/</url>
         </repository>
     </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>payara-nexus-artifacts</id>
+            <name>Payara Public Artifacts</name>
+            <url>https://nexus.dev.payara.fish/repository/payara-artifacts/</url>
+        </pluginRepository>
+    </pluginRepositories>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>fish.payara.server.core</groupId>
+                <artifactId>core-bom</artifactId>
+                <version>${payara.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
@@ -88,15 +103,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.internal.admin</groupId>
+            <groupId>fish.payara.server.core.admin</groupId>
             <artifactId>server-mgmt</artifactId>
-            <version>${payara.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.14.1</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
@@ -104,20 +116,6 @@
             <version>4.12.0</version>
         </dependency>
     </dependencies>
-
-    <pluginRepositories>
-        <pluginRepository>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-            <id>payara-patched-externals</id>
-            <name>Payara Patched Externals</name>
-            <url>https://raw.github.com/payara/Payara_PatchedProjects/master</url>
-        </pluginRepository>
-    </pluginRepositories>
 
     <build>
         <finalName>${project.name}</finalName>
@@ -134,7 +132,7 @@
             <plugin>
                 <groupId>org.glassfish.hk2</groupId>
                 <artifactId>hk2-inhabitant-generator</artifactId>
-                <version>2.6.1.payara-p1</version>
+                <version>3.0.2</version>
                 <executions>
                     <execution>
                         <goals>
@@ -149,28 +147,8 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>5.1.8</version>
-                <executions>
-                    <execution>
-                        <id>default-manifest</id>
-                        <phase>process-classes</phase>
-                        <goals>
-                            <goal>manifest</goal>
-                        </goals>
-                        <configuration>
-                            <instructions>
-                                <_include>-osgi.bundle</_include>
-                            </instructions>
-                            <excludeDependencies>tools-jar</excludeDependencies>
-                            <supportedProjectTypes>
-                                <supportedProjectType>glassfish-jar</supportedProjectType>
-                                <supportedProjectType>jar</supportedProjectType>
-                            </supportedProjectTypes>
-                        </configuration>
-                    </execution>
-                </executions>
+                <version>5.1.9</version>
                 <configuration>
-                    <Export-Package/>
                     <instructions>
                         <_include>-osgi.bundle</_include>
                     </instructions>
@@ -188,16 +166,16 @@
                 <plugin>
                     <groupId>org.glassfish.hk2</groupId>
                     <artifactId>osgiversion-maven-plugin</artifactId>
-                    <version>2.6.1</version>
+                    <version>3.0.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.glassfish.build</groupId>
                     <artifactId>command-security-maven-plugin</artifactId>
-                    <version>1.0.13</version>
+                    <version>1.0.17</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.2.0</version>
+                    <version>3.3.0</version>
                     <executions>
                         <execution>
                             <id>default-jar</id>
@@ -225,7 +203,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.1.2</version>
+                    <version>3.6.1</version>
                     <executions>
                         <execution>
                             <phase>package</phase>

--- a/src/main/java/fish/payara/extras/diagnostics/asadmin/BaseAsadmin.java
+++ b/src/main/java/fish/payara/extras/diagnostics/asadmin/BaseAsadmin.java
@@ -77,7 +77,7 @@ public abstract class BaseAsadmin extends LocalDomainCommand {
      * Configures a valid directory to use in commands.
      *
      * @param params
-     * @return Map<String, String>
+     * @return Map&lt;String, Object&gt;
      */
     protected Map<String, Object> resolveDir(Map<String, Object> params) {
         if (params == null) {

--- a/src/main/java/fish/payara/extras/diagnostics/asadmin/CollectAsadmin.java
+++ b/src/main/java/fish/payara/extras/diagnostics/asadmin/CollectAsadmin.java
@@ -51,15 +51,14 @@ import fish.payara.extras.diagnostics.collection.CollectorService;
 import fish.payara.extras.diagnostics.util.ParamConstants;
 import fish.payara.extras.diagnostics.util.PropertiesFile;
 import fish.payara.extras.diagnostics.util.TargetType;
+import jakarta.inject.Inject;
 import org.glassfish.api.Param;
 import org.glassfish.api.admin.CommandException;
 import org.glassfish.hk2.api.PerLookup;
 import org.glassfish.hk2.api.ServiceLocator;
 import org.jvnet.hk2.annotations.Service;
 import org.jvnet.hk2.config.ConfigParser;
-import org.jvnet.hk2.config.DomDocument;
 
-import javax.inject.Inject;
 import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;

--- a/src/main/java/fish/payara/extras/diagnostics/collection/CollectorService.java
+++ b/src/main/java/fish/payara/extras/diagnostics/collection/CollectorService.java
@@ -225,9 +225,7 @@ public class CollectorService {
      * Returns list of collectors which are enabled from user parameters.
      *
      * @param parameterMap
-     * @param parameterOptions
-     * @param collectors
-     * @return List<Collector>
+     * @return List&lt;Collector&gt;
      */
     public List<Collector> getActiveCollectors(Map<String, Object> parameterMap) {
         List<Collector> activeCollectors = new ArrayList<>();

--- a/src/main/java/fish/payara/extras/diagnostics/upload/uploaders/NexusAPI.java
+++ b/src/main/java/fish/payara/extras/diagnostics/upload/uploaders/NexusAPI.java
@@ -65,7 +65,7 @@ public class NexusAPI implements Uploader {
     private static final String CONTENT_TYPE_MULTIPART_BOUNDARY = "multipart/form-data; boundary=";
     private static final String AUTHORIZATION_HEADER = "Authorization";
 
-    private static final String REPO_SYS_PROP = System.getProperty("fish.payara.diagnostics.repo");
+    private static final String REPO_SYS_PROP_NAME = "fish.payara.diagnostics.repo";
 
     private static final int SUCCESS_HTTP_RESPONSE_CODE = 204;
 
@@ -75,7 +75,7 @@ public class NexusAPI implements Uploader {
 
     /**
      * Will upload specified file to Payara Nexus, using specified username and password for authentication.
-     * The repository that it will be uploaded to depends on {@value #REPO_SYS_PROP}
+     * The repository that it will be uploaded to depends on the value of the {@value REPO_SYS_PROP_NAME} property
      *
      * @param file
      * @param username
@@ -88,7 +88,7 @@ public class NexusAPI implements Uploader {
     }
 
     /**
-     * Constructs a Maven2 body as requested by Nexus, then uses a {@link MultiPartBodyPublisher} to upload to the provided nexus URL, using multipart/form-data.
+     * Constructs a Maven2 body as requested by Nexus, then uploads to the provided nexus URL using multipart/form-data.
      *
      * @return int
      */
@@ -156,14 +156,15 @@ public class NexusAPI implements Uploader {
     /**
      * Returns the URI required to upload to a repository.
      * <p>
-     * Will use username as the repository target, or {@value #REPO_SYS_PROP} system property if not null.
+     * Will use username as the repository target, or {@value REPO_SYS_PROP_NAME} system property if not null.
      *
      * @return URI
      */
     private String resolveNexusURL() {
         StringBuilder builder = new StringBuilder(NEXUS_URL).append("?repository=");
-        if (REPO_SYS_PROP != null) {
-            builder.append(REPO_SYS_PROP);
+        String repo = System.getProperty(REPO_SYS_PROP_NAME);
+        if (repo != null) {
+            builder.append(repo);
         } else if (username != null) {
             builder.append(username);
         }


### PR DESCRIPTION
Updates the payara.version to the latest Core version, sets the Java level to 11, and aligns various dependencies with the versions used by Payara 6.

Also makes some extra changes required for generating javadoc, sources, signing, and release.