### PR TITLE
FISH-8384 Structure Zip Name

### DIFF
--- a/src/main/java/fish/payara/extras/diagnostics/asadmin/BaseAsadmin.java
+++ b/src/main/java/fish/payara/extras/diagnostics/asadmin/BaseAsadmin.java
@@ -47,9 +47,13 @@ import org.glassfish.api.ExecutionContext;
 import org.glassfish.api.Param;
 import org.glassfish.api.ParamDefaultCalculator;
 
+import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.Map;
 import java.util.logging.Level;
 
@@ -59,7 +63,6 @@ public abstract class BaseAsadmin extends LocalDomainCommand {
     private static final String JAV_DIR_SYS_PROP = "user.home";
 
     protected static final String DIR_PARAM = ParamConstants.DIR_PARAM;
-    protected static final String DIR_NAME = "/payara-diagnostics-" + System.currentTimeMillis();
 
     private static final String PROPERTIES_PARAM = ParamConstants.PROPERTIES_PARAM;
     private static final String PROPERTIES_FILE_NAME = "." + PROPERTIES_PARAM;
@@ -86,7 +89,11 @@ public abstract class BaseAsadmin extends LocalDomainCommand {
 
         if (dir != null) {
             if (Files.isDirectory(Paths.get(dir))) {
-                dir = dir + DIR_NAME;
+                if (!dir.endsWith(File.separator)) {
+                    dir = dir + File.separator;
+                }
+                dir = dir + "payara-diagnostics-" + getDomainName() + "-" +
+                        DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ssX").withZone(ZoneOffset.UTC).format(Instant.now());
             }
             params.put(DIR_PARAM, dir);
         }

--- a/src/main/java/fish/payara/extras/diagnostics/asadmin/CollectAsadmin.java
+++ b/src/main/java/fish/payara/extras/diagnostics/asadmin/CollectAsadmin.java
@@ -71,45 +71,28 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import static fish.payara.extras.diagnostics.util.ParamConstants.CLUSTERS;
-import static fish.payara.extras.diagnostics.util.ParamConstants.DEPLOYMENT_GROUPS;
-import static fish.payara.extras.diagnostics.util.ParamConstants.INSTANCE;
-import static fish.payara.extras.diagnostics.util.ParamConstants.INSTANCES_DOMAIN_XML_PATH;
-import static fish.payara.extras.diagnostics.util.ParamConstants.INSTANCES_LOG_PATH;
-
 @Service(name = "collect-diagnostics")
 @PerLookup
 public class CollectAsadmin extends BaseAsadmin {
-    private static final String DOMAIN_NAME_PARAM = ParamConstants.DOMAIN_NAME_PARAM;
-    private static final String TARGET_PARAM = ParamConstants.TARGET_PARAM;
-    private static final String SERVER_LOG_PARAM = ParamConstants.SERVER_LOG_PARAM;
-    private static final String DOMAIN_XML_PARAM = ParamConstants.DOMAIN_XML_PARAM;
-    private static final String THREAD_DUMP_PARAM = ParamConstants.THREAD_DUMP_PARAM;
-    private static final String JVM_REPORT_PARAM = ParamConstants.JVM_REPORT_PARAM;
-    private static final String DOMAIN_NAME = ParamConstants.DOMAIN_NAME;
-    private static final String DOMAIN_XML_FILE_PATH = ParamConstants.DOMAIN_XML_FILE_PATH;
-    private static final String LOGS_PATH = ParamConstants.LOGS_PATH;
-    private static final String INSTANCES_NAMES = ParamConstants.INSTANCES_NAMES;
-    private static final String STANDALONE_INSTANCES = ParamConstants.STANDALONE_INSTANCES;
-    private static final String NODES = ParamConstants.NODES;
+
     Logger LOGGER = Logger.getLogger(this.getClass().getName());
 
-    @Param(name = SERVER_LOG_PARAM, optional = true, defaultValue = "true")
+    @Param(name = ParamConstants.SERVER_LOG_PARAM, optional = true, defaultValue = "true")
     private boolean collectServerLog;
 
-    @Param(name = DOMAIN_XML_PARAM, optional = true, defaultValue = "true")
+    @Param(name = ParamConstants.DOMAIN_XML_PARAM, optional = true, defaultValue = "true")
     private boolean collectDomainXml;
 
-    @Param(name = THREAD_DUMP_PARAM, optional = true, defaultValue = "true")
+    @Param(name = ParamConstants.THREAD_DUMP_PARAM, optional = true, defaultValue = "true")
     private boolean collectThreadDump;
 
-    @Param(name = JVM_REPORT_PARAM, optional = true, defaultValue = "true")
+    @Param(name = ParamConstants.JVM_REPORT_PARAM, optional = true, defaultValue = "true")
     private boolean collectJvmReport;
 
-    @Param(name = DOMAIN_NAME_PARAM, optional = true, primary = true, defaultValue = "domain1")
+    @Param(name = ParamConstants.DOMAIN_NAME_PARAM, optional = true, primary = true, defaultValue = "domain1")
     private String domainName;
 
-    @Param(name = TARGET_PARAM, optional = true, defaultValue = "domain")
+    @Param(name = ParamConstants.TARGET_PARAM, optional = true, defaultValue = "domain")
     private String target;
 
     private CollectorService collectorService;
@@ -178,25 +161,25 @@ public class CollectAsadmin extends BaseAsadmin {
      */
     private Map<String, Object> populateParameters(Map<String, Object> params) {
         //Parameter Options
-        params.put(SERVER_LOG_PARAM, getOption(SERVER_LOG_PARAM));
-        params.put(DOMAIN_XML_PARAM, getOption(DOMAIN_XML_PARAM));
-        params.put(THREAD_DUMP_PARAM, getOption(THREAD_DUMP_PARAM));
-        params.put(JVM_REPORT_PARAM, getOption(JVM_REPORT_PARAM));
-        params.put(DOMAIN_NAME, getOption(DOMAIN_NAME));
+        params.put(ParamConstants.SERVER_LOG_PARAM, getOption(ParamConstants.SERVER_LOG_PARAM));
+        params.put(ParamConstants.DOMAIN_XML_PARAM, getOption(ParamConstants.DOMAIN_XML_PARAM));
+        params.put(ParamConstants.THREAD_DUMP_PARAM, getOption(ParamConstants.THREAD_DUMP_PARAM));
+        params.put(ParamConstants.JVM_REPORT_PARAM, getOption(ParamConstants.JVM_REPORT_PARAM));
+        params.put(ParamConstants.DOMAIN_NAME, getOption(ParamConstants.DOMAIN_NAME));
 
         //Paths
-        params.put(DOMAIN_XML_FILE_PATH, getDomainXml().getAbsolutePath());
-        params.put(INSTANCES_DOMAIN_XML_PATH, getInstancePaths(PathType.DOMAIN));
-        params.put(INSTANCES_LOG_PATH, getInstancePaths(PathType.LOG));
-        params.put(LOGS_PATH, getDomainRootDir().getPath() + "/logs");
+        params.put(ParamConstants.DOMAIN_XML_FILE_PATH, getDomainXml().getAbsolutePath());
+        params.put(ParamConstants.INSTANCES_DOMAIN_XML_PATH, getInstancePaths(PathType.DOMAIN));
+        params.put(ParamConstants.INSTANCES_LOG_PATH, getInstancePaths(PathType.LOG));
+        params.put(ParamConstants.LOGS_PATH, getDomainRootDir().getPath() + "/logs");
 
         //Other
-        params.put(INSTANCES_NAMES, getInstancesNames());
-        params.put(STANDALONE_INSTANCES, getStandaloneLocalInstances());
-        params.put(NODES, getNodes());
-        params.put(DEPLOYMENT_GROUPS, getDeploymentGroups().getDeploymentGroup());
-        params.put(CLUSTERS, getClusters().getCluster());
-        params.put(INSTANCE, getInstance(target));
+        params.put(ParamConstants.INSTANCES_NAMES, getInstancesNames());
+        params.put(ParamConstants.STANDALONE_INSTANCES, getStandaloneLocalInstances());
+        params.put(ParamConstants.NODES, getNodes());
+        params.put(ParamConstants.DEPLOYMENT_GROUPS, getDeploymentGroups().getDeploymentGroup());
+        params.put(ParamConstants.CLUSTERS, getClusters().getCluster());
+        params.put(ParamConstants.INSTANCE, getInstance(target));
         return params;
     }
 


### PR DESCRIPTION
Structures the output file so that it includes a UTC timestamp and the domain name.

Also includes some cleanup - removing redundant Strings and fixing a javadoc error.

Testing done:
* Ran command against default domain: `collect-diagnostics --dir D:\Downloads\`
* Ran command against a non-default domain:
  * `create-domain --portbase 5000 --nopassword testy`
  * `collect-diagnostics --dir D:\Downloads testy`
* Set computer timezone to UTC+2
* Ran diagnostic command, timestamp was still in UTC.

Output was in the format of `payara-diagnostics-${domainName}-2024-03-08THH-mm-ssZ`