### PR TITLE
FISH-8227 Add Heap Dump for Domain

### DIFF
--- a/src/main/java/fish/payara/extras/diagnostics/asadmin/CollectAsadmin.java
+++ b/src/main/java/fish/payara/extras/diagnostics/asadmin/CollectAsadmin.java
@@ -95,6 +95,9 @@ public class CollectAsadmin extends BaseAsadmin {
     @Param(name = ParamConstants.TARGET_PARAM, optional = true, defaultValue = "domain")
     private String target;
 
+    @Param(name = ParamConstants.HEAP_DUMP_PARAM, optional = true, defaultValue = "true")
+    private boolean collectHeapDump;
+
     private CollectorService collectorService;
     private Domain domain;
 
@@ -165,6 +168,7 @@ public class CollectAsadmin extends BaseAsadmin {
         params.put(ParamConstants.DOMAIN_XML_PARAM, getOption(ParamConstants.DOMAIN_XML_PARAM));
         params.put(ParamConstants.THREAD_DUMP_PARAM, getOption(ParamConstants.THREAD_DUMP_PARAM));
         params.put(ParamConstants.JVM_REPORT_PARAM, getOption(ParamConstants.JVM_REPORT_PARAM));
+        params.put(ParamConstants.HEAP_DUMP_PARAM, getOption(ParamConstants.HEAP_DUMP_PARAM));
         params.put(ParamConstants.DOMAIN_NAME, getOption(ParamConstants.DOMAIN_NAME));
 
         //Paths

--- a/src/main/java/fish/payara/extras/diagnostics/collection/CollectorService.java
+++ b/src/main/java/fish/payara/extras/diagnostics/collection/CollectorService.java
@@ -47,6 +47,7 @@ import com.sun.enterprise.config.serverbeans.Node;
 import com.sun.enterprise.config.serverbeans.Server;
 import fish.payara.enterprise.config.serverbeans.DeploymentGroup;
 import fish.payara.extras.diagnostics.collection.collectors.DomainXmlCollector;
+import fish.payara.extras.diagnostics.collection.collectors.HeapDumpCollector;
 import fish.payara.extras.diagnostics.collection.collectors.JVMCollector;
 import fish.payara.extras.diagnostics.collection.collectors.LogCollector;
 import fish.payara.extras.diagnostics.util.JvmCollectionType;
@@ -85,6 +86,7 @@ public class CollectorService {
     private Boolean serverLog;
     private Boolean threadDump;
     private Boolean jvmReport;
+    private Boolean heapDump;
 
     Map<String, Object> parameterMap;
 
@@ -102,13 +104,14 @@ public class CollectorService {
         serverLog = true;
         threadDump = true;
         jvmReport = true;
+        heapDump = true;
 
         if (parameterMap != null) {
             domainXml = parameterMap.get(DOMAIN_XML_PARAM) == null || Boolean.parseBoolean((String) parameterMap.get(DOMAIN_XML_PARAM));
             serverLog = parameterMap.get(SERVER_LOG_PARAM) == null || Boolean.parseBoolean((String) parameterMap.get(SERVER_LOG_PARAM));
             threadDump = parameterMap.get(THREAD_DUMP_PARAM) == null || Boolean.parseBoolean((String) parameterMap.get(THREAD_DUMP_PARAM));
             jvmReport = parameterMap.get(JVM_REPORT_PARAM) == null || Boolean.parseBoolean((String) parameterMap.get(JVM_REPORT_PARAM));
-
+            heapDump = parameterMap.get(HEAP_DUMP_PARAM) == null || Boolean.parseBoolean((String) parameterMap.get(HEAP_DUMP_PARAM));
         }
     }
 
@@ -251,6 +254,10 @@ public class CollectorService {
 
             if (threadDump) {
                 activeCollectors.add(new JVMCollector(environment, programOptions, "server", JvmCollectionType.THREAD_DUMP));
+            }
+
+            if (heapDump) {
+                activeCollectors.add(new HeapDumpCollector("server", programOptions, environment));
             }
 
             addInstanceCollectors(activeCollectors, (List<Server>) parameterMap.get(STANDALONE_INSTANCES), "");

--- a/src/main/java/fish/payara/extras/diagnostics/collection/collectors/HeapDumpCollector.java
+++ b/src/main/java/fish/payara/extras/diagnostics/collection/collectors/HeapDumpCollector.java
@@ -1,0 +1,91 @@
+package fish.payara.extras.diagnostics.collection.collectors;
+
+import com.sun.enterprise.admin.cli.Environment;
+import com.sun.enterprise.admin.cli.ProgramOptions;
+import com.sun.enterprise.admin.cli.remote.RemoteCLICommand;
+import fish.payara.extras.diagnostics.collection.Collector;
+import fish.payara.extras.diagnostics.util.ParamConstants;
+import org.glassfish.api.admin.CommandException;
+import org.glassfish.api.admin.ParameterMap;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.logging.Logger;
+
+public class HeapDumpCollector implements Collector {
+
+    private Map<String, Object> params;
+
+    private String target;
+    private ProgramOptions programOptions;
+    private Logger LOGGER = Logger.getLogger(HeapDumpCollector.class.getName());
+    private Environment environment;
+
+    private String dirSuffix;
+
+    public HeapDumpCollector(String target, ProgramOptions programOptions, Environment environment) {
+        this.target = target;
+        this.programOptions = programOptions;
+        this.environment = environment;
+    }
+
+    public HeapDumpCollector(String target, ProgramOptions programOptions, Environment environment, String dirSuffix) {
+        this.target = target;
+        this.programOptions = programOptions;
+        this.environment = environment;
+        this.dirSuffix = dirSuffix;
+    }
+    @Override
+    public int collect() {
+        try{
+            ParameterMap parameterMap = new ParameterMap();
+            if (!target.equals("server")) {
+                parameterMap.add("target", target);
+            }
+
+            String outputPathString = (String) params.get(ParamConstants.DIR_PARAM);
+            Path outputPath = Paths.get(outputPathString, dirSuffix != null ? dirSuffix : "");
+            if (!Files.exists(outputPath)) {
+                Files.createDirectories(outputPath);
+            }
+            parameterMap.add("outputDir", outputPath.toString());
+            programOptions.updateOptions(parameterMap);
+            programOptions.setInteractive(false);
+            LOGGER.info("Collecting Heap Dump from " + target);
+
+            RemoteCLICommand remoteCLICommand = new RemoteCLICommand("generate-heap-dump", programOptions, environment);
+            String result = remoteCLICommand.executeAndReturnOutput();
+            System.out.println(result);
+            if (result.startsWith("Warning:") && result.contains("seems to be offline; command generate-heap-dump was not replicated to that instance")) {
+                System.out.printf("%s is offline! Heap Dump will NOT be collected!%n", target);
+                return 1;
+            }
+        } catch (CommandException e) {
+            if (e.getMessage().contains("Remote server does not listen for requests on")) {
+                System.out.print("Server is offline! Heap Dump will not be collected!\n");
+                return 0;
+            }
+
+            throw new RuntimeException(e);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        return 0;
+    }
+
+    @Override
+    public Map<String, Object> getParams() {
+        return params;
+    }
+
+    @Override
+    public void setParams(Map<String, Object> params) {
+        if (params != null) {
+            this.params = params;
+        }
+    }
+}

--- a/src/main/java/fish/payara/extras/diagnostics/util/ParamConstants.java
+++ b/src/main/java/fish/payara/extras/diagnostics/util/ParamConstants.java
@@ -52,6 +52,7 @@ public final class ParamConstants {
     public static final String DOMAIN_XML_PARAM = "domainXml";
     public static final String THREAD_DUMP_PARAM = "threadDump";
     public static final String JVM_REPORT_PARAM = "jvmReport";
+    public static final String HEAP_DUMP_PARAM = "heapDump";
 
     //Upload Params
     public static final String USERNAME_PARAM = "username";


### PR DESCRIPTION
Runs a remote command to payara which generates the heap dump.

Simply build tool and install to payara5/glassfish/lib/asadmin 
Start domain
Run ./asadmin collect-diagnostics
Make sure heap dump is present.