### PR TITLE
FISH-8393 Fix Server Log Exception

### DIFF
--- a/src/main/java/fish/payara/extras/diagnostics/collection/collectors/LogCollector.java
+++ b/src/main/java/fish/payara/extras/diagnostics/collection/collectors/LogCollector.java
@@ -121,12 +121,11 @@ public class LogCollector extends FileCollector {
         public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
 
             Path relativePath = path.relativize(file);
+            if (!file.getFileName().toString().contains(".log")) {
+                return FileVisitResult.CONTINUE;
+            }
 
             if (instanceName != null) {
-                if (relativePath.startsWith(instanceName)) {
-                    return FileVisitResult.CONTINUE;
-                }
-                Files.createDirectories(destination.resolve(path.relativize(file)).getParent());
                 String prefix = instanceName + "-";
                 if ((prefix + relativePath).startsWith(prefix + instanceName)) {
                     prefix = "";


### PR DESCRIPTION
Create the following directory in server logs `\logs\server\tx\recoveryfile`

Test before and after for collection.

Just checks to see if logs are actually logs and doesn't copy the .gitkeep file anymore.