### PR TITLE
FISH-8177 obfuscate ip addresses hostnames in domain xml payara6

### DIFF
--- a/src/main/java/fish/payara/extras/diagnostics/collection/CollectorService.java
+++ b/src/main/java/fish/payara/extras/diagnostics/collection/CollectorService.java
@@ -266,7 +266,9 @@ public class CollectorService {
     private void compressDirectory(Path filePath, ZipOutputStream zipOutputStream) throws IOException {
         Files.walkFileTree(filePath, new SimpleFileVisitor<Path>() {
             public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-                zipOutputStream.putNextEntry(new ZipEntry(filePath.relativize(file).toString()));
+                //https://pkware.cachefly.net/webdocs/APPNOTE/APPNOTE-6.3.10.TXT paragraph 4.4.17.1
+                String entryName = filePath.relativize(file).toString().replace("\\", "/");
+                zipOutputStream.putNextEntry(new ZipEntry(entryName));
                 Files.copy(file, zipOutputStream);
                 zipOutputStream.closeEntry();
                 return FileVisitResult.CONTINUE;

--- a/src/main/java/fish/payara/extras/diagnostics/util/DomainXmlUtil.java
+++ b/src/main/java/fish/payara/extras/diagnostics/util/DomainXmlUtil.java
@@ -66,11 +66,13 @@ public class DomainXmlUtil {
     private static final String ADDRESS_ATTRIBUTE = "address";
     private static final String DEFAULT_HOST = "localhost";
     private static final String HOST_ATTRIBUTE = "host";
+    private static final String NODE_HOST_ATTRIBUTE = "node-host";
+    private static final String PUBLIC_ADDRESS_ATTRIBUTE = "public-address";
     private static final String PASSWORD_KEYWORD = "password";
     private static final String ADMIN_PASSWORD_KEYWORD = "admin-password";
     private static final String NAME_ATTRIBUTE = "name";
     private static final String VALUE_ATTRIBUTE = "value";
-    private static final String URL_KEYWORD = "URL";
+    private static final String URL_KEYWORD = "url";
 
     private int obfuscatedCounter = 1;
     private Map<String,String> hostsReplacements = new HashMap<>();
@@ -119,7 +121,7 @@ public class DomainXmlUtil {
                     element.setAttribute(VALUE_ATTRIBUTE, PASSWORD_CHANGE);
                 }
             }
-            if (URL_KEYWORD.equalsIgnoreCase(nameAttribute)) {
+            if (nameAttribute.toLowerCase().contains(URL_KEYWORD)) {
                 String obfuscatedUrl = "";
                 String urlAttribute = element.getAttribute(VALUE_ATTRIBUTE);
                 if (urlAttribute.startsWith("jdbc:")) {
@@ -144,6 +146,8 @@ public class DomainXmlUtil {
     private void obfuscateAddressAndHost (Element element) {
         obfuscateAttribute(element, ADDRESS_ATTRIBUTE);
         obfuscateAttribute(element, HOST_ATTRIBUTE);
+        obfuscateAttribute(element, PUBLIC_ADDRESS_ATTRIBUTE);
+        obfuscateAttribute(element, NODE_HOST_ATTRIBUTE);
     }
 
     private void obfuscateAttribute(Element element, String attributeName) {


### PR DESCRIPTION
(`Payara6`) Obfuscates the addresses and hosts in the domain.xml file. Address `'0.0.0.0'` and host `'localhost'` are kept. Along with this, if an address or host appears more than once, it will be named the same. for example, 2 instances of `1.2.3.4` would appear as `OBFUSCATED_HOST_X`.
Obfuscated jdbc url so it keeps the database type. for example, `jdbc:h2:xxxxx` is replaced by `jdbc:h2:database-obfuscated`.

A change has also been made to the directory creation for the zip file as it before used '\' and now it uses '/'. (last commit)
I have attached a link in the description in commit 12fa245.

To test I created new addresses in IIOP, Network Listeners and JMS Hosts, leaving some values default.
command used to test:
```
./asadmin collect-diagnostics
```