### PR TITLE
FISH-9818 diagnostic tool ldap bind dn password not obfuscated payara6

### DIFF
--- a/src/main/java/fish/payara/extras/diagnostics/collection/collectors/LogCollector.java
+++ b/src/main/java/fish/payara/extras/diagnostics/collection/collectors/LogCollector.java
@@ -88,7 +88,11 @@ public class LogCollector extends FileCollector {
         Path outputPath = Paths.get(outputPathString, dirSuffix != null ? dirSuffix : "");
 
         if (confirmPath(logPath, false) && confirmPath(outputPath, true)) {
-            collectLogs(logPath, outputPath.resolve("logs"), logName);
+            if (logName.equals("access_log")) {
+                collectLogs(logPath, outputPath.resolve("logs/access"), logName);
+            } else {
+                collectLogs(logPath, outputPath.resolve("logs"), logName);
+            }
         }
 
         return 0;

--- a/src/main/java/fish/payara/extras/diagnostics/util/DomainXmlUtil.java
+++ b/src/main/java/fish/payara/extras/diagnostics/util/DomainXmlUtil.java
@@ -47,7 +47,6 @@ import org.w3c.dom.NodeList;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
@@ -70,6 +69,7 @@ public class DomainXmlUtil {
     private static final String PUBLIC_ADDRESS_ATTRIBUTE = "public-address";
     private static final String PASSWORD_KEYWORD = "password";
     private static final String PRINCIPAL_PASSWORD_ATTRIBUTE = "default-principal-password";
+    private static final String BIND_DN_PASSWORD_ATTRIBUTE = "bind-dn-password";
     private static final String ADMIN_PASSWORD_KEYWORD = "admin-password";
     private static final String NAME_ATTRIBUTE = "name";
     private static final String VALUE_ATTRIBUTE = "value";
@@ -106,18 +106,12 @@ public class DomainXmlUtil {
     private void traverseNodes(Node node) {
         if (node.getNodeType() == Node.ELEMENT_NODE) {
             Element element = (Element) node;
-            boolean hasPasswordAttribute = element.hasAttribute(PASSWORD_KEYWORD);
-            boolean hasAdminPasswordAttribute = element.hasAttribute(ADMIN_PASSWORD_KEYWORD);
-            boolean hasPrincipalPasswordAttribute = element.hasAttribute(PRINCIPAL_PASSWORD_ATTRIBUTE);
-            if (hasPasswordAttribute) {
-                element.setAttribute(PASSWORD_KEYWORD, PASSWORD_CHANGE);
-            }
-            if (hasAdminPasswordAttribute) {
-                element.setAttribute(ADMIN_PASSWORD_KEYWORD, PASSWORD_CHANGE);
-            }
-            if (hasPrincipalPasswordAttribute) {
-                element.setAttribute(PRINCIPAL_PASSWORD_ATTRIBUTE, PASSWORD_CHANGE);
-            }
+
+            obfuscateElementAttribute(element, PASSWORD_KEYWORD);
+            obfuscateElementAttribute(element, ADMIN_PASSWORD_KEYWORD);
+            obfuscateElementAttribute(element, PRINCIPAL_PASSWORD_ATTRIBUTE);
+            obfuscateElementAttribute(element, BIND_DN_PASSWORD_ATTRIBUTE);
+
 
             String nameAttribute = element.getAttribute(NAME_ATTRIBUTE);
             boolean hasValueAttribute = element.hasAttribute(VALUE_ATTRIBUTE);
@@ -148,11 +142,19 @@ public class DomainXmlUtil {
         }
     }
 
+    private void obfuscateElementAttribute(Element element, String elementAttribute) {
+        boolean hasValueAttribute = element.hasAttribute(elementAttribute);
+        if (hasValueAttribute) {
+            element.setAttribute(elementAttribute, PASSWORD_CHANGE);
+        }
+    }
+
     private void obfuscateAddressAndHost (Element element) {
         obfuscateAttribute(element, ADDRESS_ATTRIBUTE);
         obfuscateAttribute(element, HOST_ATTRIBUTE);
         obfuscateAttribute(element, PUBLIC_ADDRESS_ATTRIBUTE);
         obfuscateAttribute(element, NODE_HOST_ATTRIBUTE);
+        obfuscateAttribute(element, URL_KEYWORD);
     }
 
     private void obfuscateAttribute(Element element, String attributeName) {


### PR DESCRIPTION
(Payara6) Previously, bind_dn_password was not obfuscated in the domain xml. 

I have made changes to the `DomainXmlUtil` by creating a new function called `obfuscateElementAttribute` which  improves the readability of the program as the list of node elements was getting too long so I made it into a function as they all had the same functionality. 

I have created a private static final for the bind_dn_password keyword and included it in obfuscation. I have also included the URL keyword in the function  `obfuscateAddressAndHost` as the url for the LDAP needs to be obfuscated.

Finally, I have made changes to the `LogCollector`. When the logs are collected, the program will create a folder called logs for  the server and notification logs and then create another folder called access just for the access logs. The code I have added is so that if it is collecting an access log it will copy it into the directory `logs/access/accesslog.txt`