### PR TITLE
FISH-9754 Implemented obfuscation for logs using regex.

### DIFF
--- a/src/main/java/fish/payara/extras/diagnostics/collection/CollectorService.java
+++ b/src/main/java/fish/payara/extras/diagnostics/collection/CollectorService.java
@@ -323,21 +323,21 @@ public class CollectorService {
 
             if (domainXml) {
                 Path domainXmlPath = Paths.get((String) parameterMap.get(DOMAIN_XML_FILE_PATH));
-                activeCollectors.add(new DomainXmlCollector(domainXmlPath, obfuscateDomainXml));
+                activeCollectors.add(new DomainXmlCollector(domainXmlPath, obfuscateDomainXml, this));
             }
             if (serverLog) {
                 Path serverLogPath = Paths.get((String) parameterMap.get(LOGS_PATH));
-                activeCollectors.add(new LogCollector(serverLogPath, "server.log"));
+                activeCollectors.add(new LogCollector(serverLogPath, "server.log", this));
             }
 
             if (accessLog) {
                 Path accessLogPath = Paths.get((String) parameterMap.get(LOGS_PATH), "access");
-                activeCollectors.add(new LogCollector(accessLogPath, "access_log"));
+                activeCollectors.add(new LogCollector(accessLogPath, "access_log", this));
             }
 
             if (notificationLog) {
                 Path notificationLogPath = Paths.get((String) parameterMap.get(LOGS_PATH));
-                activeCollectors.add(new LogCollector(notificationLogPath, "notification.log"));
+                activeCollectors.add(new LogCollector(notificationLogPath, "notification.log", this));
             }
 
             boolean correctDomainRunning = correctDomainRunning();
@@ -392,20 +392,20 @@ public class CollectorService {
     private List<Collector> getLocalCollectors(String instanceRoot) {
         List<Collector> activeCollectors = new ArrayList<>();
         if (domainXml) {
-            activeCollectors.add(new DomainXmlCollector(Paths.get(instanceRoot, "config", "domain.xml"), target, null, obfuscateDomainXml));
+            activeCollectors.add(new DomainXmlCollector(Paths.get(instanceRoot, "config", "domain.xml"), target, null, obfuscateDomainXml, this));
         }
 
         Path logsPath = Paths.get(instanceRoot, "logs");
         if (serverLog) {
-            activeCollectors.add(new LogCollector(logsPath, target, "server.log"));
+            activeCollectors.add(new LogCollector(logsPath, target, "server.log", this));
         }
 
         if (accessLog) {
-            activeCollectors.add(new LogCollector(Paths.get(logsPath.toString(), "access"), target, "access_log"));
+            activeCollectors.add(new LogCollector(Paths.get(logsPath.toString(), "access"), target, "access_log", this));
         }
 
         if (notificationLog) {
-            activeCollectors.add(new LogCollector(logsPath, target, "notification.log"));
+            activeCollectors.add(new LogCollector(logsPath, target, "notification.log", this));
         }
 
         if (jvmReport) {
@@ -425,21 +425,21 @@ public class CollectorService {
         for (Server server : serversList) {
             String finalDirSuffix = Paths.get(dirSuffix, server.getName()).toString();
             if (domainXml) {
-                activeCollectors.add(new DomainXmlCollector(Paths.get(domainUtil.getNodePaths().get(server.getNodeRef()).toString(), server.getName(), "config", "domain.xml"), server.getName(), finalDirSuffix, obfuscateDomainXml));
+                activeCollectors.add(new DomainXmlCollector(Paths.get(domainUtil.getNodePaths().get(server.getNodeRef()).toString(), server.getName(), "config", "domain.xml"), server.getName(), finalDirSuffix, obfuscateDomainXml, this));
             }
 
             Path logPath = Paths.get(domainUtil.getNodePaths().get(server.getNodeRef()).toString(), server.getName(), "logs");
 
             if (serverLog) {
-                activeCollectors.add(new LogCollector(logPath, server.getName(), finalDirSuffix, "server.log"));
+                activeCollectors.add(new LogCollector(logPath, server.getName(), finalDirSuffix, "server.log", this));
             }
 
             if (accessLog) {
-                activeCollectors.add(new LogCollector(Paths.get(logPath.toString(), "access"), server.getName(), finalDirSuffix, "access_log"));
+                activeCollectors.add(new LogCollector(Paths.get(logPath.toString(), "access"), server.getName(), finalDirSuffix, "access_log", this));
             }
 
             if (notificationLog) {
-                activeCollectors.add(new LogCollector(logPath, server.getName(), finalDirSuffix, "notification.log"));
+                activeCollectors.add(new LogCollector(logPath, server.getName(), finalDirSuffix, "notification.log", this));
             }
 
             if (jvmReport) {
@@ -497,5 +497,9 @@ public class CollectorService {
         } catch (CommandException e) {
             return false;
         }
+    }
+
+    public boolean getObfuscateEnabled() {
+        return obfuscateDomainXml;
     }
 }

--- a/src/main/java/fish/payara/extras/diagnostics/collection/collectors/DomainXmlCollector.java
+++ b/src/main/java/fish/payara/extras/diagnostics/collection/collectors/DomainXmlCollector.java
@@ -40,7 +40,8 @@
 
 package fish.payara.extras.diagnostics.collection.collectors;
 
-import fish.payara.extras.diagnostics.util.DomainXmlUtil;
+import fish.payara.extras.diagnostics.collection.CollectorService;
+import fish.payara.extras.diagnostics.util.Obfuscation;
 import fish.payara.extras.diagnostics.util.ParamConstants;
 
 import java.nio.file.Path;
@@ -55,14 +56,13 @@ public class DomainXmlCollector extends FileCollector {
     private Logger LOGGER = Logger.getLogger(DomainXmlCollector.class.getName());
     private boolean obfuscateDomainXml;
     private final int COLLECTED_OKAY = 0;
-    private final DomainXmlUtil domainXmlUtil = new DomainXmlUtil();
 
-    public DomainXmlCollector(Path path, boolean obfuscateDomainXml) {
+    public DomainXmlCollector(Path path, boolean obfuscateDomainXml, CollectorService collectorService) {
         this.path = path;
         this.obfuscateDomainXml = obfuscateDomainXml;
     }
 
-    public DomainXmlCollector(Path path, String instanceName, String dirSuffix, boolean obfuscateDomainXml) {
+    public DomainXmlCollector(Path path, String instanceName, String dirSuffix, boolean obfuscateDomainXml, CollectorService collectorService) {
         this.path = path;
         super.setInstanceName(instanceName);
         this.dirSuffix = dirSuffix;
@@ -81,7 +81,7 @@ public class DomainXmlCollector extends FileCollector {
                 LOGGER.info("Collecting domain.xml from " + (getInstanceName() != null ? getInstanceName() : "server"));
                 domainXmlCollected = super.collect();
                 if (domainXmlCollected == COLLECTED_OKAY && obfuscateDomainXml) {
-                    domainXmlUtil.obfuscateDomainXml(resolveDestinationFile().toFile());
+                    Obfuscation.obfuscateDomainXml(resolveDestinationFile().toFile());
                 }
             }
         }

--- a/src/main/java/fish/payara/extras/diagnostics/util/Obfuscation.java
+++ b/src/main/java/fish/payara/extras/diagnostics/util/Obfuscation.java
@@ -81,6 +81,7 @@ public class Obfuscation {
     private static final String NAME_ATTRIBUTE = "name";
     private static final String VALUE_ATTRIBUTE = "value";
     private static final String URL_KEYWORD = "url";
+    private static final Pattern IP_ADDRESS_PATTERN = Pattern.compile("(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])");
 
     public static Map<String,String> hostsReplacements = new HashMap<>();
 
@@ -185,7 +186,6 @@ public class Obfuscation {
     public static void obfuscateLogData(Path sourceFile, Path destinationFile) throws IOException {
         try (BufferedReader reader = Files.newBufferedReader(sourceFile);
              BufferedWriter writer = Files.newBufferedWriter(destinationFile)) {
-            Pattern pattern = Pattern.compile("(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])");
             String line;
             while ((line = reader.readLine()) != null) {
                 for (Map.Entry<String, String> entry : hostsReplacements.entrySet()) {
@@ -193,14 +193,14 @@ public class Obfuscation {
                     String value = entry.getValue();
                     line = line.replace(key, value);
                 }
-                Matcher matcher = pattern.matcher(line);
+                Matcher matcher = IP_ADDRESS_PATTERN.matcher(line);
                 while (matcher.find()){
                     String hostName = matcher.group();
                     if (!hostName.equals(DEFAULT_ADDRESS)){
                         String obfuscatedReplacement = Obfuscation.OBFUSCATED_CHANGE + (hostsReplacements.size() + 1);
                         hostsReplacements.put(hostName, obfuscatedReplacement);
                         line = line.replace(hostName, obfuscatedReplacement);
-                        matcher = pattern.matcher(line);
+                        matcher = IP_ADDRESS_PATTERN.matcher(line);
                     }
                 }
                 writer.write(line);


### PR DESCRIPTION
(Payara6) I have implemented obfuscation for the logs. The `LogCollector` class calls the `Obfuscation` class which contains the functionality involved with obfuscating files. 

In the `LogCollector` I have updated the constructors to include the `CollectorService` as I needed to pass the boolean variable `obfuscateDomainXml` as to use it as a way to indentify if the obfuscation parameter is set to true which is then used in the if statement in the function `visitFile` which will lead to the function created in `Obfuscation`.

The `obfuscateLogData` function uses a regex to identify different IP Addresses and checks to see if it is equal to the default address which is `0.0.0.0`. It then goes throw the log trying to match a key from the map `hostReplacements` and rewriting the value accordingly.
