### PR TITLE
FISH-10118 FISH-10119 collect JVM/Thread dump from a remote ssh node

### DIFF
--- a/src/main/java/fish/payara/extras/diagnostics/collection/CollectorService.java
+++ b/src/main/java/fish/payara/extras/diagnostics/collection/CollectorService.java
@@ -46,9 +46,6 @@ import com.sun.enterprise.admin.cli.remote.RemoteCLICommand;
 import com.sun.enterprise.config.serverbeans.Cluster;
 import com.sun.enterprise.config.serverbeans.Domain;
 import com.sun.enterprise.config.serverbeans.Server;
-import com.sun.enterprise.universal.process.ProcessManager;
-import com.sun.enterprise.universal.process.ProcessManagerException;
-import com.sun.enterprise.util.SystemPropertyConstants;
 import fish.payara.enterprise.config.serverbeans.DeploymentGroup;
 import fish.payara.extras.diagnostics.collection.collectors.DomainXmlCollector;
 import fish.payara.extras.diagnostics.collection.collectors.HeapDumpCollector;
@@ -57,11 +54,14 @@ import fish.payara.extras.diagnostics.collection.collectors.LogCollector;
 import fish.payara.extras.diagnostics.util.DomainUtil;
 import fish.payara.extras.diagnostics.util.JvmCollectionType;
 import fish.payara.extras.diagnostics.util.TargetType;
+import org.glassfish.api.ActionReport;
 import org.glassfish.api.admin.CommandException;
+import org.glassfish.api.admin.ParameterMap;
 import org.glassfish.api.logging.LogLevel;
 import org.glassfish.hk2.api.ServiceLocator;
 import org.jvnet.hk2.config.ConfigParser;
 
+import javax.json.JsonString;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -70,6 +70,7 @@ import java.net.URL;
 import java.nio.file.*;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -100,6 +101,8 @@ public class CollectorService {
     private final ServiceLocator serviceLocator;
     private final Map<String, Object> parameterMap;
     private final String nodeDir;
+    private List<String> instanceList = new ArrayList<>();
+    private Map<String, String> instanceWithType = new HashMap<>();
 
     public CollectorService(Map<String, Object> params, Environment environment, ProgramOptions programOptions, String target, ServiceLocator serviceLocator, String domainName, String nodeDir) {
         this.parameterMap = params;
@@ -151,28 +154,34 @@ public class CollectorService {
         if (parameterMap.containsKey(DOMAIN_XML_FILE_PATH)) {
             domain = getDomain((String) parameterMap.get(DOMAIN_XML_FILE_PATH));
         }
-        List<Collector> activeCollectors;
 
+        List<Collector> activeCollectors = new ArrayList<>();
+        // Populates the `targets` list
+        getInstanceList();
+        String instanceTargetPlaceholder = "";
         if (domain == null) {
-            if (target.equals("domain")) {
-                LOGGER.info("No domain found! Nothing will be collected");
+            if (instanceList.isEmpty()) {
+                LOGGER.info("No instances found! Nothing will be collected.");
                 return 1;
             }
-            String instanceRoot = getInstanceRoot();
-            if (instanceRoot == null) return 1;
-            activeCollectors = getLocalCollectors(instanceRoot);
-
         } else {
             domainUtil = new DomainUtil(domain);
-            activeCollectors = getActiveCollectors(parameterMap, getTargetType());
+            TargetType targetType = getTargetType();
 
-            if (activeCollectors.isEmpty()) {
-                String instanceRoot = getInstanceRoot();
-                if (instanceRoot == null) return 1;
-                activeCollectors = getLocalCollectors(instanceRoot);
+            switch (targetType) {
+                case DOMAIN:
+                        activeCollectors = getActiveCollectors(parameterMap, targetType, instanceList.get(0));
+                    break;
+                case DEPLOYMENT_GROUP:
+                case CLUSTER:
+                    activeCollectors = getActiveCollectors(parameterMap, targetType, instanceTargetPlaceholder);
+                    break;
+                case INSTANCE:
+                    int indexOfInstance = instanceList.indexOf(target);
+                    activeCollectors = getActiveCollectors(parameterMap, targetType, instanceList.get(indexOfInstance));
+                    break;
             }
         }
-
 
         if (activeCollectors.isEmpty()) {
             LOGGER.info("No collectors are active. Nothing will be collected!");
@@ -205,37 +214,62 @@ public class CollectorService {
         return result;
     }
 
-    private String getInstanceRoot() {
-        String instanceRoot;
-        File asadmin = new File(SystemPropertyConstants.getAsAdminScriptLocation());
-        List<String> command = new ArrayList<>();
-        command.add(asadmin.getAbsolutePath());
-        command.add("--interactive=false");
-        command.add("_get-instance-install-dir");
-
-        if (nodeDir != null) {
-            command.add("--nodedir=" + nodeDir);
-        }
-
-        command.add(target);
-
-        ProcessManager processManager = new ProcessManager(command);
-        processManager.waitForReaderThreads(true);
+    private void getInstanceList() {
         try {
-            processManager.setEcho(false);
-            processManager.execute();
-            if (processManager.getExitValue() == 0) {
-                String result = processManager.getStdout();
-                instanceRoot = result.replace("Command _get-instance-install-dir executed successfully.", "").trim();
-            } else {
-                LOGGER.info("Target not found! Try specifying the nodedir parameter");
-                return null;
+            ParameterMap parameterMap = new ParameterMap();
+            parameterMap.add("long", "true");
+            programOptions.updateOptions(parameterMap);
+
+
+            RemoteCLICommand listNodesRemoteCLICommand = new RemoteCLICommand("list-nodes", programOptions, environment);
+            String nodesOutput = listNodesRemoteCLICommand.executeAndReturnOutput();
+            //Action report does not contain the referenceBy values and the node type.
+            //ActionReport nodesResult = listNodesRemoteCLICommand.executeAndReturnActionReport();
+
+            RemoteCLICommand listInstancesRemoteCLICommand = new RemoteCLICommand("list-instances", programOptions, environment);
+            ActionReport instanceResult = listInstancesRemoteCLICommand.executeAndReturnActionReport("list-instances");
+
+            if (instanceResult.getActionExitCode() == ActionReport.ExitCode.SUCCESS) {
+                List<Map<String, Object>> instanceList = (List<Map<String, Object>>) instanceResult.getExtraProperties().get("instanceList");
+
+                boolean skipFirstLine = true;
+                String[] lines = nodesOutput.split("\\n");
+                int referencedByIndex = nodesOutput.indexOf("Referenced By");
+
+                for (String line : lines) {
+                    if (skipFirstLine) {
+                        skipFirstLine = false;
+                        continue;
+                    }
+                    String[] parts = line.split("\\s+");
+
+                    if (parts.length >= 2) {
+                        String nodeType = parts[1];
+                        String nodeReferenceBy = line.substring(referencedByIndex).trim();
+                        String[]  instances = nodeReferenceBy.split(", ");
+                        for (String instance : instances) {
+                            if (!instance.isEmpty()){
+                                LOGGER.info("Adding instance: " + instance + " with type: " + nodeType);
+                                instanceWithType.put(instance, nodeType);
+                            }
+                        }
+                    }
+                }
+
+                for (Map<String, Object> instance : instanceList) {
+                    Object nameObject = instance.get("name");
+                    String instanceName = ((JsonString) nameObject).getString();
+                    this.instanceList.add(instanceName);
+                }
+                LOGGER.info("Instance List " + this.instanceList);
             }
-        } catch (ProcessManagerException e) {
-            throw new RuntimeException(e);
+        } catch (Exception e) {
+            if (instanceList.isEmpty()) {
+                LOGGER.info("No instances found! Nothing will be collected.");
+            }
+            LOGGER.log(LogLevel.SEVERE, "Could not execute command. " , e);
         }
-        return instanceRoot;
-    }
+        }
 
     public TargetType getTargetType() {
         if (target.equals("domain")) {
@@ -313,48 +347,45 @@ public class CollectorService {
      * @param parameterMap
      * @return List&lt;Collector&gt;
      */
-    public List<Collector> getActiveCollectors(Map<String, Object> parameterMap, TargetType targetType) {
+    public List<Collector> getActiveCollectors(Map<String, Object> parameterMap, TargetType targetType, String currentTarget) {
         List<Collector> activeCollectors = new ArrayList<>();
 
         if (parameterMap == null) {
             return activeCollectors;
         }
+
+        boolean correctDomainRunning = correctDomainRunning();
+        String instanceType = instanceWithType.get(currentTarget);
+
         if (targetType == TargetType.DOMAIN) {
+            if (instanceType.equals("CONFIG")) {
+                //The collectors inside this block, will copy the files with no folder
+                if (domainXml) {
+                    Path domainXmlPath = Paths.get((String) parameterMap.get(DOMAIN_XML_FILE_PATH));
+                    activeCollectors.add(new DomainXmlCollector(domainXmlPath, obfuscateDomainXml));
+                }
+                if (serverLog) {
+                    Path serverLogPath = Paths.get((String) parameterMap.get(LOGS_PATH));
+                    activeCollectors.add(new LogCollector(serverLogPath, "server.log"));
+                }
+                if (accessLog) {
+                    Path accessLogPath = Paths.get((String) parameterMap.get(LOGS_PATH), "access");
+                    activeCollectors.add(new LogCollector(accessLogPath, "access_log"));
+                }
 
-            if (domainXml) {
-                Path domainXmlPath = Paths.get((String) parameterMap.get(DOMAIN_XML_FILE_PATH));
-                activeCollectors.add(new DomainXmlCollector(domainXmlPath, obfuscateDomainXml));
-            }
-            if (serverLog) {
-                Path serverLogPath = Paths.get((String) parameterMap.get(LOGS_PATH));
-                activeCollectors.add(new LogCollector(serverLogPath, "server.log"));
-            }
-
-            if (accessLog) {
-                Path accessLogPath = Paths.get((String) parameterMap.get(LOGS_PATH), "access");
-                activeCollectors.add(new LogCollector(accessLogPath, "access_log"));
-            }
-
-            if (notificationLog) {
-                Path notificationLogPath = Paths.get((String) parameterMap.get(LOGS_PATH));
-                activeCollectors.add(new LogCollector(notificationLogPath, "notification.log"));
-            }
-
-            boolean correctDomainRunning = correctDomainRunning();
-            if (jvmReport) {
-                activeCollectors.add(new JVMCollector(environment, programOptions, "server", JvmCollectionType.JVM_REPORT, correctDomainRunning));
-            }
-
-            if (threadDump) {
-                activeCollectors.add(new JVMCollector(environment, programOptions, "server", JvmCollectionType.THREAD_DUMP, correctDomainRunning));
+                if (notificationLog) {
+                    Path notificationLogPath = Paths.get((String) parameterMap.get(LOGS_PATH));
+                    activeCollectors.add(new LogCollector(notificationLogPath, "notification.log"));
+                }
+                if (heapDump) {
+                    activeCollectors.add(new HeapDumpCollector(currentTarget, programOptions, environment, correctDomainRunning));
+                }
             }
 
-            if (heapDump) {
-                activeCollectors.add(new HeapDumpCollector("server", programOptions, environment, correctDomainRunning));
-            }
-
+            //adds folder for instance
             addInstanceCollectors(activeCollectors, domainUtil.getStandaloneLocalInstances(), "");
 
+            //adds folder for DG
             for (DeploymentGroup deploymentGroup : domainUtil.getDeploymentGroups().getDeploymentGroup()) {
                 addInstanceCollectors(activeCollectors, deploymentGroup.getInstances(), deploymentGroup.getName());
             }
@@ -362,12 +393,11 @@ public class CollectorService {
             for (Cluster cluster : domainUtil.getClusters().getCluster()) {
                 addInstanceCollectors(activeCollectors, cluster.getInstances(), cluster.getName());
             }
-
         }
 
         if (targetType == TargetType.INSTANCE) {
             List<Server> servers = new ArrayList<>();
-            servers.add(domainUtil.getInstance(target));
+            servers.add(domainUtil.getInstance(currentTarget));
             addInstanceCollectors(activeCollectors, servers, "");
         }
 
@@ -389,59 +419,29 @@ public class CollectorService {
         return activeCollectors;
     }
 
-    private List<Collector> getLocalCollectors(String instanceRoot) {
-        List<Collector> activeCollectors = new ArrayList<>();
-        if (domainXml) {
-            activeCollectors.add(new DomainXmlCollector(Paths.get(instanceRoot, "config", "domain.xml"), target, null, obfuscateDomainXml));
-        }
-
-        Path logsPath = Paths.get(instanceRoot, "logs");
-        if (serverLog) {
-            activeCollectors.add(new LogCollector(logsPath, target, "server.log"));
-        }
-
-        if (accessLog) {
-            activeCollectors.add(new LogCollector(Paths.get(logsPath.toString(), "access"), target, "access_log"));
-        }
-
-        if (notificationLog) {
-            activeCollectors.add(new LogCollector(logsPath, target, "notification.log"));
-        }
-
-        if (jvmReport) {
-            activeCollectors.add(new JVMCollector(environment, programOptions, target, JvmCollectionType.JVM_REPORT));
-        }
-
-        if (threadDump) {
-            activeCollectors.add(new JVMCollector(environment, programOptions, target, JvmCollectionType.THREAD_DUMP));
-        }
-        if (heapDump) {
-            activeCollectors.add(new HeapDumpCollector(target, programOptions, environment));
-        }
-        return activeCollectors;
-    }
 
     private void addInstanceCollectors(List<Collector> activeCollectors, List<Server> serversList, String dirSuffix) {
         for (Server server : serversList) {
             String finalDirSuffix = Paths.get(dirSuffix, server.getName()).toString();
-            if (domainXml) {
+            String instanceType = instanceWithType.get(server.getName());
+
+            if (domainXml && instanceType.equals("CONFIG")) {
                 activeCollectors.add(new DomainXmlCollector(Paths.get(domainUtil.getNodePaths().get(server.getNodeRef()).toString(), server.getName(), "config", "domain.xml"), server.getName(), finalDirSuffix, obfuscateDomainXml));
             }
 
-            Path logPath = Paths.get(domainUtil.getNodePaths().get(server.getNodeRef()).toString(), server.getName(), "logs");
+            if (instanceType.equals("CONFIG")) {
+                Path logPath = Paths.get(domainUtil.getNodePaths().get(server.getNodeRef()).toString(), server.getName(), "logs");
+                if (serverLog) {
+                    activeCollectors.add(new LogCollector(logPath, server.getName(), finalDirSuffix, "server.log"));
+                }
+                if (accessLog) {
+                    activeCollectors.add(new LogCollector(Paths.get(logPath.toString(), "access"), server.getName(), finalDirSuffix, "access_log"));
+                }
 
-            if (serverLog) {
-                activeCollectors.add(new LogCollector(logPath, server.getName(), finalDirSuffix, "server.log"));
+                if (notificationLog) {
+                    activeCollectors.add(new LogCollector(logPath, server.getName(), finalDirSuffix, "notification.log"));
+                }
             }
-
-            if (accessLog) {
-                activeCollectors.add(new LogCollector(Paths.get(logPath.toString(), "access"), server.getName(), finalDirSuffix, "access_log"));
-            }
-
-            if (notificationLog) {
-                activeCollectors.add(new LogCollector(logPath, server.getName(), finalDirSuffix, "notification.log"));
-            }
-
             if (jvmReport) {
                 activeCollectors.add(new JVMCollector(environment, programOptions, server.getName(), JvmCollectionType.JVM_REPORT, finalDirSuffix));
             }
@@ -449,7 +449,7 @@ public class CollectorService {
             if (threadDump) {
                 activeCollectors.add(new JVMCollector(environment, programOptions, server.getName(), JvmCollectionType.THREAD_DUMP, finalDirSuffix));
             }
-            if (heapDump) {
+            if (heapDump && instanceType.equals("CONFIG")) {
                 activeCollectors.add(new HeapDumpCollector(server.getName(), programOptions, environment, finalDirSuffix));
             }
         }

--- a/src/main/java/fish/payara/extras/diagnostics/collection/CollectorService.java
+++ b/src/main/java/fish/payara/extras/diagnostics/collection/CollectorService.java
@@ -362,20 +362,20 @@ public class CollectorService {
                 //The collectors inside this block, will copy the files with no folder
                 if (domainXml) {
                     Path domainXmlPath = Paths.get((String) parameterMap.get(DOMAIN_XML_FILE_PATH));
-                    activeCollectors.add(new DomainXmlCollector(domainXmlPath, obfuscateDomainXml));
+                    activeCollectors.add(new DomainXmlCollector(domainXmlPath, obfuscateDomainXml, this));
                 }
                 if (serverLog) {
                     Path serverLogPath = Paths.get((String) parameterMap.get(LOGS_PATH));
-                    activeCollectors.add(new LogCollector(serverLogPath, "server.log"));
+                    activeCollectors.add(new LogCollector(serverLogPath, "server.log", this));
                 }
                 if (accessLog) {
                     Path accessLogPath = Paths.get((String) parameterMap.get(LOGS_PATH), "access");
-                    activeCollectors.add(new LogCollector(accessLogPath, "access_log"));
+                    activeCollectors.add(new LogCollector(accessLogPath, "access_log", this));
                 }
 
                 if (notificationLog) {
                     Path notificationLogPath = Paths.get((String) parameterMap.get(LOGS_PATH));
-                    activeCollectors.add(new LogCollector(notificationLogPath, "notification.log"));
+                    activeCollectors.add(new LogCollector(notificationLogPath, "notification.log", this));
                 }
                 if (heapDump) {
                     activeCollectors.add(new HeapDumpCollector(currentTarget, programOptions, environment, correctDomainRunning));
@@ -427,20 +427,20 @@ public class CollectorService {
             String instanceType = instanceWithType.get(server.getName());
 
             if (domainXml && instanceType.equals("CONFIG")) {
-                activeCollectors.add(new DomainXmlCollector(Paths.get(domainUtil.getNodePaths().get(server.getNodeRef()).toString(), server.getName(), "config", "domain.xml"), server.getName(), finalDirSuffix, obfuscateDomainXml));
+                activeCollectors.add(new DomainXmlCollector(Paths.get(domainUtil.getNodePaths().get(server.getNodeRef()).toString(), server.getName(), "config", "domain.xml"), server.getName(), finalDirSuffix, obfuscateDomainXml, this));
             }
 
             if (instanceType.equals("CONFIG")) {
                 Path logPath = Paths.get(domainUtil.getNodePaths().get(server.getNodeRef()).toString(), server.getName(), "logs");
                 if (serverLog) {
-                    activeCollectors.add(new LogCollector(logPath, server.getName(), finalDirSuffix, "server.log"));
+                    activeCollectors.add(new LogCollector(logPath, server.getName(), finalDirSuffix, "server.log", this));
                 }
                 if (accessLog) {
-                    activeCollectors.add(new LogCollector(Paths.get(logPath.toString(), "access"), server.getName(), finalDirSuffix, "access_log"));
+                    activeCollectors.add(new LogCollector(Paths.get(logPath.toString(), "access"), server.getName(), finalDirSuffix, "access_log", this));
                 }
 
                 if (notificationLog) {
-                    activeCollectors.add(new LogCollector(logPath, server.getName(), finalDirSuffix, "notification.log"));
+                    activeCollectors.add(new LogCollector(logPath, server.getName(), finalDirSuffix, "notification.log", this));
                 }
             }
             if (jvmReport) {

--- a/src/main/java/fish/payara/extras/diagnostics/collection/CollectorService.java
+++ b/src/main/java/fish/payara/extras/diagnostics/collection/CollectorService.java
@@ -165,9 +165,11 @@ public class CollectorService {
                 return 1;
             }
         } else {
+            if (instanceList.isEmpty()) {
+                return 1;
+            }
             domainUtil = new DomainUtil(domain);
             TargetType targetType = getTargetType();
-
             switch (targetType) {
                 case DOMAIN:
                         activeCollectors = getActiveCollectors(parameterMap, targetType, instanceList.get(0));

--- a/src/main/java/fish/payara/extras/diagnostics/collection/collectors/JVMCollector.java
+++ b/src/main/java/fish/payara/extras/diagnostics/collection/collectors/JVMCollector.java
@@ -111,7 +111,8 @@ public class JVMCollector implements Collector {
         String suffix = jvmCollectionType == JvmCollectionType.JVM_REPORT ? "-jvm-report.txt" : "-thread-dump.txt";
         byte[] textBytes = text.getBytes();
         try {
-            Files.write(Paths.get(outputPath + "/" + fileName + suffix), textBytes);
+            Files.createDirectories(outputPath);
+            Files.write(Paths.get(outputPath.toString(), fileName + suffix), textBytes);
         } catch (IOException e) {
             return false;
         }

--- a/src/main/java/fish/payara/extras/diagnostics/util/DomainUtil.java
+++ b/src/main/java/fish/payara/extras/diagnostics/util/DomainUtil.java
@@ -31,19 +31,17 @@ public class DomainUtil {
         return domain.getNodes().getNode();
     }
 
-    public List<Server> getLocalInstances() {
+    public List<Server> getInstances() {
         List<Server> instances = new ArrayList<>();
         List<Node> nodes = getNodes();
         for (Node node : nodes) {
-            if (node.isLocal()) {
-                instances.addAll(domain.getInstancesOnNode(node.getName()));
-            }
+            instances.addAll(domain.getInstancesOnNode(node.getName()));
         }
         return instances;
     }
 
     public List<Server> getStandaloneLocalInstances() {
-        List<Server> instances = getLocalInstances();
+        List<Server> instances = getInstances();
 
         for (DeploymentGroup dg : getDeploymentGroups().getDeploymentGroup()) {
             for (Server dgInstance : dg.getInstances()) {
@@ -60,7 +58,7 @@ public class DomainUtil {
     }
 
     public Server getInstance(String instance) {
-        for (Server server : getLocalInstances()) {
+        for (Server server : getInstances()) {
             if (server.getName().equals(instance)) {
                 return server;
             }
@@ -110,9 +108,9 @@ public class DomainUtil {
     }
 
     public List<String> getInstancesNames() {
-        List<Server> localInstances = getLocalInstances();
+        List<Server> instances = getInstances();
         List<String> instanceNames = new ArrayList<>();
-        localInstances.forEach(instance -> instanceNames.add(instance.getName()));
+        instances.forEach(instance -> instanceNames.add(instance.getName()));
 
         return instanceNames;
     }


### PR DESCRIPTION
As explained in the Remote Instance design page.

**_Changes made to the `CollectorService`:_**
The `CollectorService` has been changed to look for remote instances. The `ExecuteCollection` has been changed so it calls a function called `getInstancesList` which will use an asadmin command `list-nodes --long` and `list-instances` to populate two fields. `instancesWithType`, which will contain a map of the instance name and its respective node type ("CONFIG" or "SSH") and `targetLists` which will contain a list of all the instances.

The `getInstancesList` function was previously named `getInstanceRoot` which would only get the root directory of the instance. This forces the Diagnostic Tool to only look for local instances and so it has been changed to fit the new purpose.

The switch statement determines if the user has set a target and which type it is. Depending on which TargetType it is, it will call the `getActiveCollectors` with a new parameter which will be used to determine the instance name.

In the ` getActiveCollectors` the function will call the `instancesWithType` to figure out if the instance is local or remote. depending on the outcome, it will either collect the logs and heap dump (currently forced to be local due to functionality issues with remote instances) or just collect the jvm report and thread dump.

If the targetType is `DOMAIN` then it will collect everything, calling a function called `addInstanceCollector` which will get all the instances in the server, check if it is local or remote and collect accordingly.

The previous function `getLocalCollectors` has been deleted as it is not necessary and it has repeated code from the other functions.

**_Changes made to the `DomainUtil`:_**
The changes made to `DomainUtil` have been minimal. I have changed the name of the function `getLocalInstances()` as the name is not true to its current functionality. Previously it was only gathering instances from local nodes, whereas now it looks for instances in all nodes.


**_How to Test_**
Copy branch into local directory
Go to directory and run `mvn clean install`
Go to target folder and copy the `.jar` file
paste the `.jar` file in **Payara Enterprise 5 ** `/payara5/glassfish/lib/asadmin/` and replace current diagnostics jar

On the Payara Server, create an SSH Node and create an instance for the respective SSH Node and start it.

use the command `./asadmin collect-diagnostics --target instanceInSSH`
`--target` can be used to target deployment groups too.