### PR TITLE
FISH-10120 collect logs from a remote ssh instance

### DIFF
--- a/src/main/java/fish/payara/extras/diagnostics/collection/CollectorService.java
+++ b/src/main/java/fish/payara/extras/diagnostics/collection/CollectorService.java
@@ -161,27 +161,28 @@ public class CollectorService {
         String instanceTargetPlaceholder = "";
         if (domain == null) {
             if (instanceList.isEmpty()) {
-                LOGGER.info("No instances found! Nothing will be collected.");
-                return 1;
+                activeCollectors = getActiveCollectors(parameterMap, TargetType.DOMAIN, instanceTargetPlaceholder);
             }
         } else {
             if (instanceList.isEmpty()) {
-                return 1;
+                activeCollectors = getActiveCollectors(parameterMap, TargetType.DOMAIN, instanceTargetPlaceholder);
             }
-            domainUtil = new DomainUtil(domain);
-            TargetType targetType = getTargetType();
-            switch (targetType) {
-                case DOMAIN:
+            else {
+                domainUtil = new DomainUtil(domain);
+                TargetType targetType = getTargetType();
+                switch (targetType) {
+                    case DOMAIN:
                         activeCollectors = getActiveCollectors(parameterMap, targetType, instanceList.get(0));
-                    break;
-                case DEPLOYMENT_GROUP:
-                case CLUSTER:
-                    activeCollectors = getActiveCollectors(parameterMap, targetType, instanceTargetPlaceholder);
-                    break;
-                case INSTANCE:
-                    int indexOfInstance = instanceList.indexOf(target);
-                    activeCollectors = getActiveCollectors(parameterMap, targetType, instanceList.get(indexOfInstance));
-                    break;
+                        break;
+                    case DEPLOYMENT_GROUP:
+                    case CLUSTER:
+                        activeCollectors = getActiveCollectors(parameterMap, targetType, instanceTargetPlaceholder);
+                        break;
+                    case INSTANCE:
+                        int indexOfInstance = instanceList.indexOf(target);
+                        activeCollectors = getActiveCollectors(parameterMap, targetType, instanceList.get(indexOfInstance));
+                        break;
+                }
             }
         }
 
@@ -360,40 +361,41 @@ public class CollectorService {
         String instanceType = instanceWithType.get(currentTarget);
 
         if (targetType == TargetType.DOMAIN) {
-            if (instanceType.equals("CONFIG")) {
                 //The collectors inside this block, will copy the files with no folder
-                if (domainXml) {
-                    Path domainXmlPath = Paths.get((String) parameterMap.get(DOMAIN_XML_FILE_PATH));
-                    activeCollectors.add(new DomainXmlCollector(domainXmlPath, obfuscateDomainXml, this));
-                }
-                if (serverLog) {
-                    Path serverLogPath = Paths.get((String) parameterMap.get(LOGS_PATH));
-                    activeCollectors.add(new LogCollector(serverLogPath, "server.log", this));
-                }
-                if (accessLog) {
-                    Path accessLogPath = Paths.get((String) parameterMap.get(LOGS_PATH), "access");
-                    activeCollectors.add(new LogCollector(accessLogPath, "access_log", this));
-                }
-
-                if (notificationLog) {
-                    Path notificationLogPath = Paths.get((String) parameterMap.get(LOGS_PATH));
-                    activeCollectors.add(new LogCollector(notificationLogPath, "notification.log", this));
-                }
-                if (heapDump) {
-                    activeCollectors.add(new HeapDumpCollector(currentTarget, programOptions, environment, correctDomainRunning));
-                }
+            if (domainXml) {
+                Path domainXmlPath = Paths.get((String) parameterMap.get(DOMAIN_XML_FILE_PATH));
+                activeCollectors.add(new DomainXmlCollector(domainXmlPath, obfuscateDomainXml, this));
             }
+            if (serverLog) {
+                activeCollectors.add(new LogCollector("server.log", this, environment, programOptions));
+            }
+//          if (accessLog) {
+//              Path accessLogPath = Paths.get((String) parameterMap.get(LOGS_PATH), "access");
+//              activeCollectors.add(new LogCollector(accessLogPath, "access_log", this, environment, programOptions));
+//          }
+//
+//          if (notificationLog) {
+//              Path notificationLogPath = Paths.get((String) parameterMap.get(LOGS_PATH));
+//              activeCollectors.add(new LogCollector(notificationLogPath, "notification.log", this,environment, programOptions));
+//          }
+            if (heapDump) {
+                activeCollectors.add(new HeapDumpCollector(currentTarget, programOptions, environment, correctDomainRunning));
+            }
+
 
             //adds folder for instance
-            addInstanceCollectors(activeCollectors, domainUtil.getStandaloneLocalInstances(), "");
+            if (!instanceList.isEmpty()) {
+                addInstanceCollectors(activeCollectors, domainUtil.getStandaloneLocalInstances(), "");
 
-            //adds folder for DG
-            for (DeploymentGroup deploymentGroup : domainUtil.getDeploymentGroups().getDeploymentGroup()) {
-                addInstanceCollectors(activeCollectors, deploymentGroup.getInstances(), deploymentGroup.getName());
-            }
 
-            for (Cluster cluster : domainUtil.getClusters().getCluster()) {
-                addInstanceCollectors(activeCollectors, cluster.getInstances(), cluster.getName());
+                //adds folder for DG
+                for (DeploymentGroup deploymentGroup : domainUtil.getDeploymentGroups().getDeploymentGroup()) {
+                    addInstanceCollectors(activeCollectors, deploymentGroup.getInstances(), deploymentGroup.getName());
+                }
+
+                for (Cluster cluster : domainUtil.getClusters().getCluster()) {
+                    addInstanceCollectors(activeCollectors, cluster.getInstances(), cluster.getName());
+                }
             }
         }
 
@@ -432,19 +434,16 @@ public class CollectorService {
                 activeCollectors.add(new DomainXmlCollector(Paths.get(domainUtil.getNodePaths().get(server.getNodeRef()).toString(), server.getName(), "config", "domain.xml"), server.getName(), finalDirSuffix, obfuscateDomainXml, this));
             }
 
-            if (instanceType.equals("CONFIG")) {
-                Path logPath = Paths.get(domainUtil.getNodePaths().get(server.getNodeRef()).toString(), server.getName(), "logs");
-                if (serverLog) {
-                    activeCollectors.add(new LogCollector(logPath, server.getName(), finalDirSuffix, "server.log", this));
-                }
-                if (accessLog) {
-                    activeCollectors.add(new LogCollector(Paths.get(logPath.toString(), "access"), server.getName(), finalDirSuffix, "access_log", this));
-                }
-
-                if (notificationLog) {
-                    activeCollectors.add(new LogCollector(logPath, server.getName(), finalDirSuffix, "notification.log", this));
-                }
+            if (serverLog) {
+                activeCollectors.add(new LogCollector(server.getName(), finalDirSuffix, "server.log", this, environment, programOptions));
             }
+//                if (accessLog) {
+//                    activeCollectors.add(new LogCollector(Paths.get(logPath.toString(), "access"), server.getName(), finalDirSuffix, "access_log", this, environment, programOptions));
+//                }
+//
+//                if (notificationLog) {
+//                    activeCollectors.add(new LogCollector(logPath, server.getName(), finalDirSuffix, "notification.log", this, environment, programOptions));
+//                }
             if (jvmReport) {
                 activeCollectors.add(new JVMCollector(environment, programOptions, server.getName(), JvmCollectionType.JVM_REPORT, finalDirSuffix));
             }
@@ -504,5 +503,9 @@ public class CollectorService {
 
     public boolean getObfuscateEnabled() {
         return obfuscateDomainXml;
+    }
+
+    public String getTarget(){
+        return target;
     }
 }

--- a/src/main/java/fish/payara/extras/diagnostics/collection/collectors/LogCollector.java
+++ b/src/main/java/fish/payara/extras/diagnostics/collection/collectors/LogCollector.java
@@ -115,7 +115,7 @@ public class LogCollector extends FileCollector {
     }
 
     private boolean collectLogs(Path outputPath) {
-        //./asadmin collect-log-files --target xx --retrieve true /home/flavio/... will create /logs/target
+        //./asadmin collect-log-files --target xx --retrieve true /home/user/... will create /logs/target
         try {
             if (!target.equals("domain")){
                 ParameterMap parameterMap = new ParameterMap();
@@ -184,6 +184,3 @@ public class LogCollector extends FileCollector {
         LOGGER.info("Unzipped logs to: " + finalOutputFilePath); // Added to see which folder/file is created first
     }
 }
-
-
-// I dont want /logs/instance/...


### PR DESCRIPTION
I have revamped the `LogCollector` class so it utilises the command `collect-log-files`.

What the command does is it collects the log files from local or remote instances and stores it in a zip file in payara5/glassfish/domains/domain1/collected-logs. The LogCollector then uses the command output to determine the location of the file and unzips the file and copies into the respective folder.

It creates the log folders accordingly depending if there is an instance or not.

If a target is used (`./asadmin collect-diagnostics --target instance`) then it will use the target and attach it to the `programOptions` which is then used for the command.

I have also added some error handling on the `CollectorService`  as if there are no instances it should still collect the logs for the server. A few bits of code has been commented out as I will need it for the next task which is to allow heap dump collection of SSH instances.