### PR TITLE
FISH-10121 collect heap dump from remote ssh nodes

### DIFF
--- a/src/main/java/fish/payara/extras/diagnostics/collection/CollectorService.java
+++ b/src/main/java/fish/payara/extras/diagnostics/collection/CollectorService.java
@@ -250,7 +250,7 @@ public class CollectorService {
                     }
                     String[] parts = line.split("\\s+");
 
-                    if (parts.length >= 2) {
+                    if (parts.length >= 4) {
                         String nodeType = parts[1];
                         String nodeName = parts[0];
                         String nodeInstallationPath = parts[3];

--- a/src/main/java/fish/payara/extras/diagnostics/collection/CollectorService.java
+++ b/src/main/java/fish/payara/extras/diagnostics/collection/CollectorService.java
@@ -60,6 +60,7 @@ import org.glassfish.api.admin.ParameterMap;
 import org.glassfish.api.logging.LogLevel;
 import org.glassfish.hk2.api.ServiceLocator;
 import org.jvnet.hk2.config.ConfigParser;
+import com.sun.enterprise.config.serverbeans.*;
 
 import jakarta.json.JsonString;
 import java.io.File;
@@ -103,6 +104,8 @@ public class CollectorService {
     private final String nodeDir;
     private List<String> instanceList = new ArrayList<>();
     private Map<String, String> instanceWithType = new HashMap<>();
+    private Map<String, String> nodeInstallationDirectories= new HashMap<>();
+    private Map<String, String> instanceInNode= new HashMap<>();
 
     public CollectorService(Map<String, Object> params, Environment environment, ProgramOptions programOptions, String target, ServiceLocator serviceLocator, String domainName, String nodeDir) {
         this.parameterMap = params;
@@ -238,6 +241,7 @@ public class CollectorService {
                 boolean skipFirstLine = true;
                 String[] lines = nodesOutput.split("\\n");
                 int referencedByIndex = nodesOutput.indexOf("Referenced By");
+                int installationPathIndex = nodesOutput.indexOf("Installation Directory");
 
                 for (String line : lines) {
                     if (skipFirstLine) {
@@ -248,13 +252,21 @@ public class CollectorService {
 
                     if (parts.length >= 2) {
                         String nodeType = parts[1];
+                        String nodeName = parts[0];
+                        String nodeInstallationPath = parts[3];
                         String nodeReferenceBy = line.substring(referencedByIndex).trim();
+                        String nodeInstallationDirectory = line.substring(installationPathIndex).trim();
                         String[]  instances = nodeReferenceBy.split(", ");
                         for (String instance : instances) {
                             if (!instance.isEmpty()){
                                 LOGGER.info("Adding instance: " + instance + " with type: " + nodeType);
                                 instanceWithType.put(instance, nodeType);
+                                instanceInNode.put(instance, nodeName);
                             }
+                        }
+                        if (!nodeInstallationDirectory.isEmpty()){
+                            LOGGER.info("Adding installation directory: " + nodeInstallationPath + " for node: " + nodeName);
+                            nodeInstallationDirectories.put(nodeName ,nodeInstallationPath);
                         }
                     }
                 }
@@ -272,7 +284,7 @@ public class CollectorService {
             }
             LOGGER.log(LogLevel.SEVERE, "Could not execute command. " , e);
         }
-        }
+    }
 
     public TargetType getTargetType() {
         if (target.equals("domain")) {
@@ -378,9 +390,6 @@ public class CollectorService {
 //              Path notificationLogPath = Paths.get((String) parameterMap.get(LOGS_PATH));
 //              activeCollectors.add(new LogCollector(notificationLogPath, "notification.log", this,environment, programOptions));
 //          }
-            if (heapDump) {
-                activeCollectors.add(new HeapDumpCollector(currentTarget, programOptions, environment, correctDomainRunning));
-            }
 
 
             //adds folder for instance
@@ -450,8 +459,8 @@ public class CollectorService {
             if (threadDump) {
                 activeCollectors.add(new JVMCollector(environment, programOptions, server.getName(), JvmCollectionType.THREAD_DUMP, finalDirSuffix));
             }
-            if (heapDump && instanceType.equals("CONFIG")) {
-                activeCollectors.add(new HeapDumpCollector(server.getName(), programOptions, environment, finalDirSuffix));
+            if (heapDump) {
+                activeCollectors.add(new HeapDumpCollector(server.getName(), programOptions, environment, finalDirSuffix, this));
             }
         }
     }
@@ -506,5 +515,22 @@ public class CollectorService {
 
     public String getTarget(){
         return target;
+    }
+
+    public String returnInstanceType(String instance) {
+        return instanceWithType.get(instance);
+    }
+
+    public Node returnCurrentNode(String instance) {
+        String nodeName = instanceInNode.get(instance);
+        return domain.getNodeNamed(nodeName);
+    }
+
+    public String returnNodeInstallationDirectory(String instance) {
+        String nodeName = instanceInNode.get(instance);
+        return nodeInstallationDirectories.get(nodeName);
+    }
+    public ServiceLocator returnServiceLocator(){
+        return serviceLocator;
     }
 }

--- a/src/main/java/fish/payara/extras/diagnostics/collection/collectors/HeapDumpCollector.java
+++ b/src/main/java/fish/payara/extras/diagnostics/collection/collectors/HeapDumpCollector.java
@@ -25,6 +25,8 @@ import java.util.regex.Pattern;
 
 public class HeapDumpCollector implements Collector {
 
+    private final String SSH = "SSH";
+
     private Map<String, Object> params;
 
     private String target;
@@ -73,7 +75,7 @@ public class HeapDumpCollector implements Collector {
                 //If it is local, uses destination folder as outputDir
                 parameterMap.add("outputDir", outputPath.toString());
             }
-            if (targetType.equals("SSH")) {
+            if (targetType.equals(SSH)) {
                 parameterMap.add("outputDir", nodeInstallationDirectory);
             }
             programOptions.updateOptions(parameterMap);
@@ -94,7 +96,7 @@ public class HeapDumpCollector implements Collector {
                 LOGGER.warning("Could not extract file name from result.");
             }
 
-            if (targetType.equals("SSH")) {
+            if (targetType.equals(SSH)) {
                 LOGGER.info("Downloading Heap Dump from remote host.");
                 String remoteFile = nodeInstallationDirectory+"/"+fileName;
                 downloadFileUsingSCP(remoteFile, outputPath.toString(), fileName);

--- a/src/main/java/fish/payara/extras/diagnostics/collection/collectors/HeapDumpCollector.java
+++ b/src/main/java/fish/payara/extras/diagnostics/collection/collectors/HeapDumpCollector.java
@@ -3,17 +3,25 @@ package fish.payara.extras.diagnostics.collection.collectors;
 import com.sun.enterprise.admin.cli.Environment;
 import com.sun.enterprise.admin.cli.ProgramOptions;
 import com.sun.enterprise.admin.cli.remote.RemoteCLICommand;
+import com.trilead.ssh2.SCPClient;
 import fish.payara.extras.diagnostics.collection.Collector;
+import fish.payara.extras.diagnostics.collection.CollectorService;
 import fish.payara.extras.diagnostics.util.ParamConstants;
 import org.glassfish.api.admin.CommandException;
 import org.glassfish.api.admin.ParameterMap;
+import org.glassfish.cluster.ssh.launcher.SSHLauncher;
+import com.sun.enterprise.config.serverbeans.*;
+import org.glassfish.hk2.api.ServiceLocator;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
 import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class HeapDumpCollector implements Collector {
 
@@ -24,30 +32,24 @@ public class HeapDumpCollector implements Collector {
     private Logger LOGGER = Logger.getLogger(HeapDumpCollector.class.getName());
     private Environment environment;
     private boolean correctDomain;
-
+    private String targetType;
+    private Node node;
+    private String nodeInstallationDirectory;
+    private ServiceLocator serviceLocator;
     private String dirSuffix;
 
-    public HeapDumpCollector(String target, ProgramOptions programOptions, Environment environment) {
-        this.target = target;
-        this.programOptions = programOptions;
-        this.environment = environment;
-        this.correctDomain = true;
-    }
-
-    public HeapDumpCollector(String target, ProgramOptions programOptions, Environment environment, boolean correctDomain) {
-        this.target = target;
-        this.programOptions = programOptions;
-        this.environment = environment;
-        this.correctDomain = correctDomain;
-    }
-
-    public HeapDumpCollector(String target, ProgramOptions programOptions, Environment environment, String dirSuffix) {
+    public HeapDumpCollector(String target, ProgramOptions programOptions, Environment environment, String dirSuffix, CollectorService collectorService) {
         this.target = target;
         this.programOptions = programOptions;
         this.environment = environment;
         this.dirSuffix = dirSuffix;
         this.correctDomain = true;
+        this.targetType = collectorService.returnInstanceType(target);
+        this.node = collectorService.returnCurrentNode(target);
+        this.serviceLocator = collectorService.returnServiceLocator();
+        this.nodeInstallationDirectory = collectorService.returnNodeInstallationDirectory(target);
     }
+
 
     @Override
     public int collect() {
@@ -62,19 +64,41 @@ public class HeapDumpCollector implements Collector {
             if (!target.equals("server")) {
                 parameterMap.add("target", target);
             }
-
             String outputPathString = (String) params.get(ParamConstants.DIR_PARAM);
             Path outputPath = Paths.get(outputPathString, dirSuffix != null ? dirSuffix : "");
             if (!Files.exists(outputPath)) {
                 Files.createDirectories(outputPath);
             }
-            parameterMap.add("outputDir", outputPath.toString());
+            if (targetType.equals("CONFIG")) {
+                //If it is local, uses destination folder as outputDir
+                parameterMap.add("outputDir", outputPath.toString());
+            }
+            if (targetType.equals("SSH")) {
+                parameterMap.add("outputDir", nodeInstallationDirectory);
+            }
             programOptions.updateOptions(parameterMap);
             programOptions.setInteractive(false);
 
             RemoteCLICommand remoteCLICommand = new RemoteCLICommand("generate-heap-dump", programOptions, environment);
             String result = remoteCLICommand.executeAndReturnOutput();
             LOGGER.info(result);
+
+            // Extract file name from command output
+            String fileName = null;
+            Pattern pattern = Pattern.compile("File name is (.+)");
+            Matcher matcher = pattern.matcher(result);
+            if (matcher.find()) {
+                fileName = matcher.group(1) + ".hprof";
+                LOGGER.info("Extracted file name: " + fileName);
+            } else {
+                LOGGER.warning("Could not extract file name from result.");
+            }
+
+            if (targetType.equals("SSH")) {
+                LOGGER.info("Downloading Heap Dump from remote host.");
+                String remoteFile = nodeInstallationDirectory+"/"+fileName;
+                downloadFileUsingSCP(remoteFile, outputPath.toString(), fileName);
+            }
             if (result.startsWith("Warning:") && result.contains("seems to be offline; command generate-heap-dump was not replicated to that instance")) {
                 LOGGER.warning(target + "is offline! Heap Dump will NOT be collected!");
             }
@@ -105,6 +129,29 @@ public class HeapDumpCollector implements Collector {
         return 0;
     }
 
+    private boolean downloadFileUsingSCP(String remoteFile, String localDirectory, String fileName) throws IOException {
+        try  {
+            ByteArrayOutputStream outStream = new ByteArrayOutputStream();
+            String deleteFileCommand = "cd " + nodeInstallationDirectory + " && rm " + fileName;
+            SSHLauncher sshL = getSSHL(serviceLocator);
+            sshL.init(node, LOGGER);
+            SCPClient scpClient = sshL.getSCPClient();
+
+            Path outputDir = Paths.get(localDirectory);
+            Path localFile = outputDir.resolve(Paths.get(remoteFile).getFileName());
+
+            scpClient.get(remoteFile, localDirectory);
+            sshL.runCommand(deleteFileCommand,outStream);
+            LOGGER.info("Heap dump file downloaded successfully to: " + localFile);
+            return true;
+        } catch (IOException e) {
+            LOGGER.severe("Error downloading heap dump file: " + e.getMessage());
+            return false;
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     @Override
     public Map<String, Object> getParams() {
         return params;
@@ -115,5 +162,9 @@ public class HeapDumpCollector implements Collector {
         if (params != null) {
             this.params = params;
         }
+    }
+
+    private SSHLauncher getSSHL(ServiceLocator habitat) {
+        return habitat.getService(SSHLauncher.class);
     }
 }


### PR DESCRIPTION
**Payara 6**

I have updated the `HeapDumpCollector` so that it generates and collects the heap dump from remote nodes.

I have created a variable that calls a function in the `CollectorService` which returns the target type of the current target (`CONFIG` = Local, `SSH` = Remote).
These values are then used to determine if the `outputdir` for the `generate-heap-dump` command will be the local directory or, if the target is SSH, it will use the `nodeInstallationDirectory` variable which will generate the heap dump in the remote machine.

After the command is executed, the file name is extracted if the target is SSH, which will then send this information to the `downloadFileUsingSCP` function. This function uses SCP to go to the file directory and copy the file to the Diagnostics folder. After the download is completed, it will remove the file from the remote machine to save space.

**Changes made to `CollectorService`**

A new map, `nodeInstallationDirectory` was created to help identify what path to look for when trying to generate the heap dump as we would not know what the remote machines path is. A function was then created to return the nodes installation directory.

A new map, `instanceInNode` was created to help identify which node the specific instance was in. This would be used to identify the current node being targeted. 

A new function has been created to return the `serviceLocator` as it would be needed to create a SSHLauncher in `HeapDumpCollector`