### PR TITLE
FISH-10375 implement access and notification log collection from remote ssh instance

### DIFF
--- a/src/main/java/fish/payara/extras/diagnostics/collection/CollectorService.java
+++ b/src/main/java/fish/payara/extras/diagnostics/collection/CollectorService.java
@@ -90,9 +90,9 @@ public class CollectorService {
     private final ProgramOptions programOptions;
     private Boolean domainXml;
     private Boolean obfuscateDomainXml;
-    private Boolean accessLog;
-    private Boolean notificationLog;
-    private Boolean serverLog;
+    public Boolean accessLog;
+    public Boolean notificationLog;
+    public Boolean serverLog;
     private Boolean threadDump;
     private Boolean jvmReport;
     private Boolean heapDump;
@@ -101,7 +101,6 @@ public class CollectorService {
     private final String domainName;
     private final ServiceLocator serviceLocator;
     private final Map<String, Object> parameterMap;
-    private final String nodeDir;
     private List<String> instanceList = new ArrayList<>();
     private Map<String, String> instanceWithType = new HashMap<>();
     private Map<String, String> nodeInstallationDirectories= new HashMap<>();
@@ -114,7 +113,6 @@ public class CollectorService {
         this.programOptions = programOptions;
         this.serviceLocator = serviceLocator;
         this.domainName = domainName;
-        this.nodeDir = nodeDir;
         init();
     }
 
@@ -373,24 +371,15 @@ public class CollectorService {
         String instanceType = instanceWithType.get(currentTarget);
 
         if (targetType == TargetType.DOMAIN) {
-                //The collectors inside this block, will copy the files with no folder
+            //The collectors inside this block, will copy the files with no folder
             if (domainXml) {
                 Path domainXmlPath = Paths.get((String) parameterMap.get(DOMAIN_XML_FILE_PATH));
                 activeCollectors.add(new DomainXmlCollector(domainXmlPath, obfuscateDomainXml, this));
             }
             if (serverLog) {
-                activeCollectors.add(new LogCollector("server.log", this, environment, programOptions));
+                boolean collectDomainLogs = true;
+                activeCollectors.add(new LogCollector("server.log", this, environment, programOptions, collectDomainLogs));
             }
-//          if (accessLog) {
-//              Path accessLogPath = Paths.get((String) parameterMap.get(LOGS_PATH), "access");
-//              activeCollectors.add(new LogCollector(accessLogPath, "access_log", this, environment, programOptions));
-//          }
-//
-//          if (notificationLog) {
-//              Path notificationLogPath = Paths.get((String) parameterMap.get(LOGS_PATH));
-//              activeCollectors.add(new LogCollector(notificationLogPath, "notification.log", this,environment, programOptions));
-//          }
-
 
             //adds folder for instance
             if (!instanceList.isEmpty()) {
@@ -444,15 +433,15 @@ public class CollectorService {
             }
 
             if (serverLog) {
-                activeCollectors.add(new LogCollector(server.getName(), finalDirSuffix, "server.log", this, environment, programOptions));
+                activeCollectors.add(new LogCollector(server.getName(), finalDirSuffix, "server.log", this, environment, programOptions, "server", false));
             }
-//                if (accessLog) {
-//                    activeCollectors.add(new LogCollector(Paths.get(logPath.toString(), "access"), server.getName(), finalDirSuffix, "access_log", this, environment, programOptions));
-//                }
-//
-//                if (notificationLog) {
-//                    activeCollectors.add(new LogCollector(logPath, server.getName(), finalDirSuffix, "notification.log", this, environment, programOptions));
-//                }
+            if (accessLog) {
+                activeCollectors.add(new LogCollector(server.getName(), finalDirSuffix, "access_log", this, environment, programOptions, "access", false));
+            }
+
+            if (notificationLog) {
+                activeCollectors.add(new LogCollector(server.getName(), finalDirSuffix, "notification.log", this, environment, programOptions, "notification", false));
+            }
             if (jvmReport) {
                 activeCollectors.add(new JVMCollector(environment, programOptions, server.getName(), JvmCollectionType.JVM_REPORT, finalDirSuffix));
             }

--- a/src/main/java/fish/payara/extras/diagnostics/collection/collectors/HeapDumpCollector.java
+++ b/src/main/java/fish/payara/extras/diagnostics/collection/collectors/HeapDumpCollector.java
@@ -105,7 +105,7 @@ public class HeapDumpCollector implements Collector {
             }
 
             if (result.startsWith("Warning:") && result.contains("seems to be offline; command generate-heap-dump was not replicated to that instance")) {
-                LOGGER.warning(target + "is offline! Heap Dump will NOT be collected!");
+                LOGGER.warning(target + " is offline! Heap Dump will NOT be collected!");
             }
         } catch (CommandException e) {
             if (e.getMessage().contains("Remote server does not listen for requests on")) {

--- a/src/main/java/fish/payara/extras/diagnostics/collection/collectors/HeapDumpCollector.java
+++ b/src/main/java/fish/payara/extras/diagnostics/collection/collectors/HeapDumpCollector.java
@@ -137,7 +137,7 @@ public class HeapDumpCollector implements Collector {
     private boolean downloadFileUsingSCP(String remoteFile, String localDirectory, String fileName) throws IOException {
         try  {
             ByteArrayOutputStream outStream = new ByteArrayOutputStream();
-            String deleteFileCommand = "cd " + nodeInstallationDirectory + " && rm " + fileName;
+            String deleteFileCommand = "rm "+ nodeInstallationDirectory +"/" + fileName;
             SSHLauncher sshL = getSSHL(serviceLocator);
             sshL.init(node, LOGGER);
             SCPClient scpClient = sshL.getSCPClient();

--- a/src/main/java/fish/payara/extras/diagnostics/collection/collectors/LogCollector.java
+++ b/src/main/java/fish/payara/extras/diagnostics/collection/collectors/LogCollector.java
@@ -43,18 +43,22 @@ package fish.payara.extras.diagnostics.collection.collectors;
 import com.sun.enterprise.admin.cli.Environment;
 import com.sun.enterprise.admin.cli.ProgramOptions;
 import com.sun.enterprise.admin.cli.remote.RemoteCLICommand;
+import com.sun.enterprise.config.serverbeans.Node;
+import com.trilead.ssh2.SCPClient;
+import com.trilead.ssh2.SFTPv3Client;
+import com.trilead.ssh2.SFTPv3DirectoryEntry;
 import fish.payara.extras.diagnostics.collection.CollectorService;
 import fish.payara.extras.diagnostics.util.ParamConstants;
 import org.glassfish.api.ActionReport;
 import org.glassfish.api.admin.CommandException;
 import org.glassfish.api.admin.ParameterMap;
+import org.glassfish.cluster.ssh.launcher.SSHLauncher;
+import org.glassfish.hk2.api.ServiceLocator;
 
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
+import java.io.*;
 import java.nio.file.*;
 import java.util.Map;
+import java.util.Vector;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -70,30 +74,43 @@ public class LogCollector extends FileCollector {
     private String dirSuffix;
     private boolean obfuscateEnabled;
     private String target;
-    private String instanceName;
+    private boolean collectNotifcationLogs;
+    private boolean retrieveAccessLogs = false;
+    private boolean collectServerLogs;
+    private String currentCollectionLogType;
     private final ProgramOptions programOptions;
     private final Environment environment;
     private Logger LOGGER = Logger.getLogger(LogCollector.class.getName());
-    private boolean logForServerCollected = false;
+    private boolean collectLogsForServer;
+    private Node node;
+    private String nodeInstallationDirectory;
+    private ServiceLocator serviceLocator;
+    private String targetType = "CONFIG";
 
-    public LogCollector(String logName, CollectorService collectorService, Environment environment, ProgramOptions programOptions) {
+    public LogCollector(String logName, CollectorService collectorService, Environment environment, ProgramOptions programOptions, boolean logsForServer) {
 
         this.logName = logName;
         this.obfuscateEnabled = collectorService.getObfuscateEnabled();
         this.environment = environment;
+        this.collectLogsForServer = logsForServer;
         this.programOptions = programOptions;
         this.target = collectorService.getTarget();
+        this.collectNotifcationLogs = collectorService.notificationLog;
+        this.collectServerLogs = collectorService.serverLog;
+
     }
 
-    public LogCollector(String instanceName, String logName, CollectorService collectorService,  Environment environment, ProgramOptions programOptions) {
-        this(logName, collectorService, environment, programOptions);
+    public LogCollector(String instanceName, String dirSuffix, String logName, CollectorService collectorService,  Environment environment, ProgramOptions programOptions, String collectionLogType, boolean logsForServer) {
+        this(logName, collectorService, environment, programOptions, logsForServer);
         super.setInstanceName(instanceName);
-        instanceName = instanceName;
-    }
-
-    public LogCollector(String instanceName, String dirSuffix, String logName, CollectorService collectorService,  Environment environment, ProgramOptions programOptions) {
-        this(instanceName, logName, collectorService, environment, programOptions);
+        target = instanceName;
+        this.targetType = collectorService.returnInstanceType(target);
+        this.node = collectorService.returnCurrentNode(target);
+        this.nodeInstallationDirectory = collectorService.returnNodeInstallationDirectory(target);
         this.dirSuffix = dirSuffix;
+        this.serviceLocator = collectorService.returnServiceLocator();
+        this.currentCollectionLogType = collectionLogType;
+
     }
 
     @Override
@@ -105,10 +122,20 @@ public class LogCollector extends FileCollector {
         String outputPathString = (String) params.get(ParamConstants.DIR_PARAM);
         Path outputPath = Paths.get(outputPathString, dirSuffix != null ? dirSuffix : "");
 
-        collectLogs(outputPath);
-        if (!logForServerCollected){
+        if (collectLogsForServer){
             collectLogs(outputPath);
-            logForServerCollected = true;
+        }
+        if (currentCollectionLogType != null){
+            switch (currentCollectionLogType) {
+                case "server":
+                case "notification":
+                    collectLogs(outputPath);
+                    break;
+                case "access":
+                    retrieveAccessLogs = true;
+                    collectLogs(outputPath);
+                    break;
+            }
         }
 
         return 0;
@@ -136,6 +163,20 @@ public class LogCollector extends FileCollector {
             }
 
             unzipFile(Paths.get(zipFilePath), outputPath);
+            if (!collectNotifcationLogs){
+                deleteNotificationOrServerLog(outputPath, "notification.log");}
+            if (!collectServerLogs){
+                deleteNotificationOrServerLog(outputPath, "server.log");
+            }
+            if (retrieveAccessLogs && targetType.equals("SSH")){
+                Path accessLogsFilePath = Paths.get(nodeInstallationDirectory + "/glassfish/nodes/" + node.getName() + "/" + getInstanceName() + "/logs/access/");
+                String accessLogFile = nodeInstallationDirectory + "/glassfish/nodes/" + node.getName() + "/" + getInstanceName() + "/logs/access/";
+                downloadAccessLogUsingSCP(accessLogFile,outputPath.toString(), logName, accessLogsFilePath);
+            }
+            if (retrieveAccessLogs && targetType.equals("CONFIG")){
+                Path accessLogsFilePath = Paths.get(nodeInstallationDirectory + "/glassfish/nodes/" + node.getName() + "/" + getInstanceName() + "/logs/access/");
+                retrieveAccessLogSLocally(outputPath.toString(),accessLogsFilePath);
+            }
 
             if (report.getActionExitCode() == ActionReport.ExitCode.SUCCESS) {
                 LOGGER.info("Log has been collected successfully");
@@ -183,4 +224,77 @@ public class LogCollector extends FileCollector {
         }
         LOGGER.info("Unzipped logs to: " + finalOutputFilePath); // Added to see which folder/file is created first
     }
+
+    private void deleteNotificationOrServerLog(Path outputDir, String deleteLogName) {
+        try {
+            Files.walk(outputDir)
+                    .filter(path -> Files.isRegularFile(path) && path.getFileName().toString().equals(deleteLogName))
+                    .forEach(path -> {
+                        try {
+                            Files.delete(path);
+                            LOGGER.info("Deleted: " + path);
+                        } catch (IOException e) {
+                            LOGGER.warning("Failed to delete: " + path + " due to " + e.getMessage());
+                        }
+                    });
+        } catch (IOException e) {
+            LOGGER.warning("Error traversing directory " + outputDir + ": " + e.getMessage());
+        }
+    }
+
+    private boolean downloadAccessLogUsingSCP(String remoteDirectory, String localAccessDirectory, String fileName, Path remoteFilePath) throws IOException {
+        try  {
+            SSHLauncher sshL = getSSHL(serviceLocator);
+            sshL.init(node, LOGGER);
+            SFTPv3Client sftpClient = sshL.getSFTPClient();
+            SCPClient scpClient = sshL.getSCPClient();
+            localAccessDirectory = localAccessDirectory+"/logs/"+getInstanceName()+"/access/";
+            Files.createDirectories(Paths.get(localAccessDirectory));
+            remoteFilePath.getFileName().toString().contains(fileName);
+
+            Vector listOfFilesInDirectory = sftpClient.ls(remoteDirectory);
+            for (Object fileObject: listOfFilesInDirectory){
+                SFTPv3DirectoryEntry file = (SFTPv3DirectoryEntry) fileObject;
+                if (file.attributes.isRegularFile()){
+                    String remoteFileName = file.filename;
+                    LOGGER.info("Downloading access log: " + remoteFileName);
+                    scpClient.get(remoteDirectory + remoteFileName, localAccessDirectory);
+                }
+            }
+            // remoteFile would be {installationDirectory} + "/glassfish/nodes/" + {node.toString()} + "/" + {instance} + "/logs/access/(file contains access_log)"
+            LOGGER.info("Access log downloaded successfully to: " + localAccessDirectory);
+            return true;
+        } catch (IOException e) {
+            LOGGER.severe("Error downloading heap dump file: " + e.getMessage());
+            return false;
+        }
+    }
+
+    private boolean retrieveAccessLogSLocally(String localAccessDirectory, Path accessLogsFilePath) {
+        try {
+            Path localAccessPath = Paths.get(localAccessDirectory+"/logs/"+getInstanceName()+"/access/");
+            Files.createDirectories(localAccessPath);
+
+            try (DirectoryStream<Path> directoryStream = Files.newDirectoryStream(accessLogsFilePath)) {
+                for (Path file : directoryStream) {
+                    if (Files.isRegularFile(file)) {
+                        Path destination = (localAccessPath.resolve(file.getFileName()));
+                        Files.copy(file, destination, StandardCopyOption.REPLACE_EXISTING);
+                        LOGGER.info("Copied access log: " + file.getFileName() + " to " + destination);
+                    }
+                }
+            }
+            LOGGER.info("All access logs have been retrieved successfully to: " + localAccessDirectory);
+            return true;
+        } catch (IOException e) {
+            LOGGER.severe("Error retrieving access logs locally: " + e.getMessage());
+            return false;
+        }
+    }
+
+
+    private SSHLauncher getSSHL(ServiceLocator habitat) {
+        return habitat.getService(SSHLauncher.class);
+    }
+
 }

--- a/src/main/java/fish/payara/extras/diagnostics/collection/collectors/LogCollector.java
+++ b/src/main/java/fish/payara/extras/diagnostics/collection/collectors/LogCollector.java
@@ -265,7 +265,7 @@ public class LogCollector extends FileCollector {
             LOGGER.info("Access log downloaded successfully to: " + localAccessDirectory);
             return true;
         } catch (IOException e) {
-            LOGGER.severe("Error downloading heap dump file: " + e.getMessage());
+            LOGGER.severe("Error downloading access logs: " + e.getMessage());
             return false;
         }
     }

--- a/src/main/java/fish/payara/extras/diagnostics/collection/collectors/LogCollector.java
+++ b/src/main/java/fish/payara/extras/diagnostics/collection/collectors/LogCollector.java
@@ -214,8 +214,9 @@ public class LogCollector extends FileCollector {
                     Files.createDirectories(finalOutputFilePath.getParent());
                     try (OutputStream os = new FileOutputStream(finalOutputFilePath.toFile())) {
                         byte[] buffer = new byte[1024];
-                        while (zis.read(buffer) > 0) {
-                            os.write(buffer);
+                        int len;
+                        while ((len = zis.read(buffer)) > 0) {
+                            os.write(buffer, 0, len);
                         }
                     }
                 }


### PR DESCRIPTION
I have changed the `LogCollector` to collect the access and notification logs.

**Access Logs**
As the `collect-log-files` command does not target folders in the logs folder, for example `logs\access`. I used SCP to download the file from the host machine if it is of `SSH`. If it is `CONFIG` then it will collect the file manually from the logs folder.

**Notification Log**
As notification logs are already collected, I have changed it so if the `collectNotificationLogs` is false, it will collect all the logs and then delete the notification log. I have also done this with the server logs as well by using a case statement. 