### PR TITLE
FISH-10559 added domain.xml collection for SSH nodes.

### DIFF
--- a/src/main/java/fish/payara/extras/diagnostics/collection/CollectorService.java
+++ b/src/main/java/fish/payara/extras/diagnostics/collection/CollectorService.java
@@ -427,8 +427,15 @@ public class CollectorService {
             String finalDirSuffix = Paths.get(dirSuffix, server.getName()).toString();
             String instanceType = instanceWithType.get(server.getName());
 
-            if (domainXml && instanceType.equals("CONFIG")) {
-                activeCollectors.add(new DomainXmlCollector(Paths.get(domainUtil.getNodePaths().get(server.getNodeRef()).toString(), server.getName(), "config", "domain.xml"), server.getName(), finalDirSuffix, obfuscateDomainXml, this));
+            if (domainXml) {
+                if (instanceType.equals("CONFIG")){
+                    activeCollectors.add(new DomainXmlCollector(Paths.get(domainUtil.getNodePaths().get(server.getNodeRef()).toString(), server.getName(), "config", "domain.xml"), server.getName(), finalDirSuffix, obfuscateDomainXml, this));
+                }
+                if (instanceType.equals("SSH")){
+                    Path domainXmlPath = Paths.get((String) parameterMap.get(DOMAIN_XML_FILE_PATH));
+                    activeCollectors.add(new DomainXmlCollector(domainXmlPath, server.getName(), finalDirSuffix, obfuscateDomainXml, this));
+                }
+
             }
 
             if (serverLog) {

--- a/src/main/java/fish/payara/extras/diagnostics/collection/CollectorService.java
+++ b/src/main/java/fish/payara/extras/diagnostics/collection/CollectorService.java
@@ -428,14 +428,15 @@ public class CollectorService {
             String instanceType = instanceWithType.get(server.getName());
 
             if (domainXml) {
-                if (instanceType.equals("CONFIG")){
-                    activeCollectors.add(new DomainXmlCollector(Paths.get(domainUtil.getNodePaths().get(server.getNodeRef()).toString(), server.getName(), "config", "domain.xml"), server.getName(), finalDirSuffix, obfuscateDomainXml, this));
+                switch (instanceType) {
+                    case "CONFIG":
+                        activeCollectors.add(new DomainXmlCollector(Paths.get(domainUtil.getNodePaths().get(server.getNodeRef()).toString(), server.getName(), "config", "domain.xml"), server.getName(), finalDirSuffix, obfuscateDomainXml, this));
+                        break;
+                    case "SSH":
+                        Path domainXmlPath = Paths.get((String) parameterMap.get(DOMAIN_XML_FILE_PATH));
+                        activeCollectors.add(new DomainXmlCollector(domainXmlPath, server.getName(), finalDirSuffix, obfuscateDomainXml, this));
+                        break;
                 }
-                if (instanceType.equals("SSH")){
-                    Path domainXmlPath = Paths.get((String) parameterMap.get(DOMAIN_XML_FILE_PATH));
-                    activeCollectors.add(new DomainXmlCollector(domainXmlPath, server.getName(), finalDirSuffix, obfuscateDomainXml, this));
-                }
-
             }
 
             if (serverLog) {


### PR DESCRIPTION
**Payara 6**

Changed domain.xml collection so both ssh and local nodes can collect from it. SSH nodes collect the domain.xml from the server whereas the local nodes collect from their own respective folder. (They are both the same anyways).