### PR TITLE
FISH-10544 Unable to collect logs when the domain is off

### DIFF
--- a/src/main/java/fish/payara/extras/diagnostics/collection/CollectorService.java
+++ b/src/main/java/fish/payara/extras/diagnostics/collection/CollectorService.java
@@ -47,10 +47,7 @@ import com.sun.enterprise.config.serverbeans.Cluster;
 import com.sun.enterprise.config.serverbeans.Domain;
 import com.sun.enterprise.config.serverbeans.Server;
 import fish.payara.enterprise.config.serverbeans.DeploymentGroup;
-import fish.payara.extras.diagnostics.collection.collectors.DomainXmlCollector;
-import fish.payara.extras.diagnostics.collection.collectors.HeapDumpCollector;
-import fish.payara.extras.diagnostics.collection.collectors.JVMCollector;
-import fish.payara.extras.diagnostics.collection.collectors.LogCollector;
+import fish.payara.extras.diagnostics.collection.collectors.*;
 import fish.payara.extras.diagnostics.util.DomainUtil;
 import fish.payara.extras.diagnostics.util.JvmCollectionType;
 import fish.payara.extras.diagnostics.util.TargetType;
@@ -96,6 +93,7 @@ public class CollectorService {
     private Boolean threadDump;
     private Boolean jvmReport;
     private Boolean heapDump;
+    private boolean serverIsOn = true;
     private Domain domain;
     private DomainUtil domainUtil;
     private final String domainName;
@@ -160,6 +158,7 @@ public class CollectorService {
         // Populates the `targets` list
         getInstanceList();
         String instanceTargetPlaceholder = "";
+
         if (domain == null) {
             if (instanceList.isEmpty()) {
                 activeCollectors = getActiveCollectors(parameterMap, TargetType.DOMAIN, instanceTargetPlaceholder);
@@ -277,6 +276,11 @@ public class CollectorService {
                 LOGGER.info("Instance List " + this.instanceList);
             }
         } catch (Exception e) {
+            if (e.getMessage().contains("Is the server up?")) {
+                LOGGER.info("Server Offline! Only domain.xml and local server logs will be collected.");
+                LOGGER.info("Turn on Server to collect from instances!");
+                serverIsOn = false;
+            }
             if (instanceList.isEmpty()) {
                 LOGGER.info("No instances found! Nothing will be collected.");
             }
@@ -377,8 +381,24 @@ public class CollectorService {
                 activeCollectors.add(new DomainXmlCollector(domainXmlPath, obfuscateDomainXml, this));
             }
             if (serverLog) {
-                boolean collectDomainLogs = true;
-                activeCollectors.add(new LogCollector("server.log", this, environment, programOptions, collectDomainLogs));
+                if (!serverIsOn) {
+                    Path serverLogPath = Paths.get((String) parameterMap.get(LOGS_PATH));
+                    activeCollectors.add(new LocalLogCollector(serverLogPath, "server.log", this));
+                } else {
+                    boolean collectDomainLogs = true;
+                    activeCollectors.add(new LogCollector("server.log", this, environment, programOptions, collectDomainLogs));
+                }
+            }
+
+            if (!serverIsOn){
+                if (notificationLog){
+                    Path serverLogPath = Paths.get((String) parameterMap.get(LOGS_PATH));
+                    activeCollectors.add(new LocalLogCollector(serverLogPath, "notification.log", this));
+                }
+                if (accessLog){
+                    Path serverLogPath = Paths.get((String) parameterMap.get(LOGS_PATH));
+                    activeCollectors.add(new LocalLogCollector(serverLogPath, "access_log", this));
+                }
             }
 
             //adds folder for instance
@@ -432,15 +452,29 @@ public class CollectorService {
                 activeCollectors.add(new DomainXmlCollector(Paths.get(domainUtil.getNodePaths().get(server.getNodeRef()).toString(), server.getName(), "config", "domain.xml"), server.getName(), finalDirSuffix, obfuscateDomainXml, this));
             }
 
+            Path logPath = Paths.get(domainUtil.getNodePaths().get(server.getNodeRef()).toString(), server.getName(), "logs");
+
             if (serverLog) {
-                activeCollectors.add(new LogCollector(server.getName(), finalDirSuffix, "server.log", this, environment, programOptions, "server", false));
+                if (!serverIsOn && instanceType.equals("CONFIG")) {
+                    activeCollectors.add(new LocalLogCollector(logPath, server.getName(), finalDirSuffix, "server.log",this));
+                } else if (serverIsOn){
+                    activeCollectors.add(new LogCollector(server.getName(), finalDirSuffix, "server.log", this, environment, programOptions, "server", false));
+                }
             }
             if (accessLog) {
-                activeCollectors.add(new LogCollector(server.getName(), finalDirSuffix, "access_log", this, environment, programOptions, "access", false));
+                if (!serverIsOn && instanceType.equals("CONFIG")) {
+                    activeCollectors.add(new LocalLogCollector(logPath, server.getName(), finalDirSuffix, "access_log",this));
+                } else if (serverIsOn){
+                    activeCollectors.add(new LogCollector(server.getName(), finalDirSuffix, "access_log", this, environment, programOptions, "access", false));
+                }
             }
 
             if (notificationLog) {
-                activeCollectors.add(new LogCollector(server.getName(), finalDirSuffix, "notification.log", this, environment, programOptions, "notification", false));
+                if (!serverIsOn && instanceType.equals("CONFIG")) {
+                    activeCollectors.add(new LocalLogCollector(logPath, server.getName(), finalDirSuffix, "notification.log",this));
+                } else if (serverIsOn) {
+                    activeCollectors.add(new LogCollector(server.getName(), finalDirSuffix, "notification.log", this, environment, programOptions, "notification", false));
+                }
             }
             if (jvmReport) {
                 activeCollectors.add(new JVMCollector(environment, programOptions, server.getName(), JvmCollectionType.JVM_REPORT, finalDirSuffix));

--- a/src/main/java/fish/payara/extras/diagnostics/collection/CollectorService.java
+++ b/src/main/java/fish/payara/extras/diagnostics/collection/CollectorService.java
@@ -290,7 +290,20 @@ public class CollectorService {
                 serverIsOn = false;
             }
             if (instanceList.isEmpty()) {
-                LOGGER.info("No instances found! Nothing will be collected.");
+                LOGGER.info("No instances found from remote command. Collecting local instances");
+                DomainUtil domainUtil = new DomainUtil(domain);
+                List<Server> localInstances = domainUtil.getStandaloneLocalInstances();
+
+                for (Server server : localInstances) {
+                    this.instanceList.add(server.getName());
+                    instanceWithType.put(server.getName(), "CONFIG");
+                }
+
+                if (instanceList.isEmpty()) {
+                    LOGGER.info("No local instances found using DomainUtil.");
+                } else {
+                    LOGGER.info("Local instances retrieved: " + instanceList);
+                }
             }
             LOGGER.log(LogLevel.SEVERE, "Could not execute command. " , e);
         }

--- a/src/main/java/fish/payara/extras/diagnostics/collection/collectors/LocalLogCollector.java
+++ b/src/main/java/fish/payara/extras/diagnostics/collection/collectors/LocalLogCollector.java
@@ -1,0 +1,177 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2023-2024 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+
+package fish.payara.extras.diagnostics.collection.collectors;
+
+import fish.payara.extras.diagnostics.collection.CollectorService;
+import fish.payara.extras.diagnostics.util.Obfuscation;
+import fish.payara.extras.diagnostics.util.ParamConstants;
+import org.glassfish.api.logging.LogLevel;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Map;
+
+public class LocalLogCollector extends FileCollector {
+
+    private Path logPath;
+    private String logName;
+    private String dirSuffix;
+    private boolean obfuscateEnabled;
+
+    public LocalLogCollector(Path logPath, String logName, CollectorService collectorService) {
+        this.logPath = logPath;
+        this.logName = logName;
+        this.obfuscateEnabled = collectorService.getObfuscateEnabled();
+    }
+
+    public LocalLogCollector(Path logPath, String instanceName, String logName, CollectorService collectorService) {
+        this(logPath, logName, collectorService);
+        super.setInstanceName(instanceName);
+    }
+
+    public LocalLogCollector(Path logPath, String instanceName, String dirSuffix, String logName, CollectorService collectorService) {
+        this(logPath, instanceName, logName, collectorService);
+        this.dirSuffix = dirSuffix;
+    }
+
+    @Override
+    public int collect() {
+        Map<String, Object> params = getParams();
+        if (params == null) {
+            return 0;
+        }
+        String outputPathString = (String) params.get(ParamConstants.DIR_PARAM);
+        Path outputPath = Paths.get(outputPathString, dirSuffix != null ? dirSuffix : "");
+
+        if (confirmPath(logPath, false) && confirmPath(outputPath, true)) {
+            if (logName.equals("access_log")) {
+                collectLogs(logPath, outputPath.resolve("logs/access"), logName);
+            } else {
+                collectLogs(logPath, outputPath.resolve("logs"), logName);
+            }
+        }
+
+        return 0;
+    }
+
+    private int collectLogs(Path sourcePath, Path destinationPath, String fileContains) {
+        if (Files.exists(sourcePath)) {
+            collectExistingLogs(sourcePath, destinationPath,fileContains);
+        } else {
+            logger.log(LogLevel.SEVERE, "Could not find directory {0}", new Object[]{sourcePath});
+            return 1;
+        }
+        return 0;
+    }
+
+    private void collectExistingLogs(Path sourcePath, Path destinationPath, String fileContains) {
+        try {
+            logger.info(String.format("Collecting %s from %s", logName, (getInstanceName() != null ? getInstanceName() : "server")));
+            CopyDirectoryVisitor copyDirectoryVisitor = new CopyDirectoryVisitor(destinationPath, fileContains);
+            copyDirectoryVisitor.setInstanceName(getInstanceName());
+            Files.walkFileTree(sourcePath, copyDirectoryVisitor);
+        } catch (IOException io) {
+            logger.log(LogLevel.SEVERE, "Could not copy directory " + sourcePath + " to path " + destinationPath.toString());
+            io.printStackTrace();
+        }
+    }
+
+    private class CopyDirectoryVisitor extends SimpleFileVisitor<Path> {
+
+        private final Path destination;
+        private Path path = null;
+        private final String fileContains;
+        private String instanceName;
+
+        public CopyDirectoryVisitor(Path destination, String fileContains) {
+            this.destination = destination;
+            this.fileContains = fileContains;
+        }
+
+        @Override
+        public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+            if (path == null) {
+                this.path = dir;
+            }
+
+            Path relativeDir = path.relativize(dir);
+            Path destinationDir = destination.resolve(relativeDir);
+            Files.createDirectories(destinationDir);
+
+            return FileVisitResult.CONTINUE;
+        }
+
+        @Override
+        public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+            Path relativePath = path.relativize(file);
+            if (!file.getFileName().toString().contains(fileContains)) {
+                return FileVisitResult.CONTINUE;
+            }
+
+            Path resolvedDestination;
+            if (instanceName != null) {
+                String prefix = instanceName + "-";
+                if ((prefix + relativePath).startsWith(prefix + instanceName)) {
+                    prefix = "";
+                }
+                resolvedDestination = destination.resolve((prefix + relativePath));
+            } else {
+                resolvedDestination = destination.resolve(relativePath);
+            }
+
+            if (obfuscateEnabled){
+                Obfuscation.obfuscateLogData(file, resolvedDestination);
+            }else {
+                Files.copy(file, resolvedDestination);
+            }
+            return FileVisitResult.CONTINUE;
+        }
+
+        public void setInstanceName(String instanceName) {
+            this.instanceName = instanceName;
+        }
+    }
+}

--- a/src/main/java/fish/payara/extras/diagnostics/collection/collectors/LocalLogCollector.java
+++ b/src/main/java/fish/payara/extras/diagnostics/collection/collectors/LocalLogCollector.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2023-2024 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023-2025 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -52,9 +52,11 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.util.logging.Logger;
 import java.util.Map;
 
 public class LocalLogCollector extends FileCollector {
+    private static final Logger LOGGER = Logger.getLogger(LocalLogCollector.class.getName());
 
     private Path logPath;
     private String logName;
@@ -101,7 +103,7 @@ public class LocalLogCollector extends FileCollector {
         if (Files.exists(sourcePath)) {
             collectExistingLogs(sourcePath, destinationPath,fileContains);
         } else {
-            logger.log(LogLevel.SEVERE, "Could not find directory {0}", new Object[]{sourcePath});
+            LOGGER.log(LogLevel.SEVERE, "Could not find directory {0}", new Object[]{sourcePath});
             return 1;
         }
         return 0;
@@ -109,12 +111,12 @@ public class LocalLogCollector extends FileCollector {
 
     private void collectExistingLogs(Path sourcePath, Path destinationPath, String fileContains) {
         try {
-            logger.info(String.format("Collecting %s from %s", logName, (getInstanceName() != null ? getInstanceName() : "server")));
+            LOGGER.info(String.format("Collecting %s from %s", logName, (getInstanceName() != null ? getInstanceName() : "server")));
             CopyDirectoryVisitor copyDirectoryVisitor = new CopyDirectoryVisitor(destinationPath, fileContains);
             copyDirectoryVisitor.setInstanceName(getInstanceName());
             Files.walkFileTree(sourcePath, copyDirectoryVisitor);
         } catch (IOException io) {
-            logger.log(LogLevel.SEVERE, "Could not copy directory " + sourcePath + " to path " + destinationPath.toString());
+            LOGGER.log(LogLevel.SEVERE, "Could not copy directory " + sourcePath + " to path " + destinationPath.toString());
             io.printStackTrace();
         }
     }

--- a/src/main/java/fish/payara/extras/diagnostics/collection/collectors/LogCollector.java
+++ b/src/main/java/fish/payara/extras/diagnostics/collection/collectors/LogCollector.java
@@ -97,7 +97,6 @@ public class LogCollector extends FileCollector {
         this.target = collectorService.getTarget();
         this.collectNotifcationLogs = collectorService.notificationLog;
         this.collectServerLogs = collectorService.serverLog;
-
     }
 
     public LogCollector(String instanceName, String dirSuffix, String logName, CollectorService collectorService,  Environment environment, ProgramOptions programOptions, String collectionLogType, boolean logsForServer) {


### PR DESCRIPTION
I have added the old code as a new class as to not overcrowd the existing `LogCollector`. 

I have created some error messages to notify the user that the server is offline and only the `local server logs` and `domain.xml` will be collected. This will determine if the variable `serverIsOn` is true or false which will guide the `activeCollectors` to see if they should use the `LogCollector` which uses the `remote commands` or the `LocalLogCollector`.

I think this is a better option as without the server being on, we are not able to find what instances there are without completely reverting back to the old code, which at that point, makes using the remote commands a bit redundant.

I think it makes sense that if the server is off, then it should only collect the `domain.xml` and the `server logs`.  