### PR TITLE
FISH-10817 --target does not exist check

### DIFF
--- a/src/main/java/fish/payara/extras/diagnostics/collection/CollectorService.java
+++ b/src/main/java/fish/payara/extras/diagnostics/collection/CollectorService.java
@@ -178,6 +178,10 @@ public class CollectorService {
             else {
                 domainUtil = new DomainUtil(domain);
                 TargetType targetType = getTargetType();
+                if (targetType == null) {
+                    LOGGER.info("Target not found! Is the name correct?");
+                    return 0;
+                }
                 switch (targetType) {
                     case DOMAIN:
                         activeCollectors = getActiveCollectors(parameterMap, targetType, instanceList.get(0));

--- a/src/main/java/fish/payara/extras/diagnostics/collection/CollectorService.java
+++ b/src/main/java/fish/payara/extras/diagnostics/collection/CollectorService.java
@@ -164,6 +164,12 @@ public class CollectorService {
 
         List<Collector> activeCollectors = new ArrayList<>();
         // Populates the `targets` list
+        domainUtil = new DomainUtil(domain);
+        TargetType targetType = getTargetType();
+        if (targetType == null) {
+            LOGGER.info("Target not found! Is the name correct?");
+            return 0;
+        }
         getInstanceList();
         String instanceTargetPlaceholder = "";
 
@@ -176,12 +182,6 @@ public class CollectorService {
                 activeCollectors = getActiveCollectors(parameterMap, TargetType.DOMAIN, instanceTargetPlaceholder);
             }
             else {
-                domainUtil = new DomainUtil(domain);
-                TargetType targetType = getTargetType();
-                if (targetType == null) {
-                    LOGGER.info("Target not found! Is the name correct?");
-                    return 0;
-                }
                 switch (targetType) {
                     case DOMAIN:
                         activeCollectors = getActiveCollectors(parameterMap, targetType, instanceList.get(0));


### PR DESCRIPTION
If the target in `collect-diagnostics --target thisDoesNotExist` does not exist, it will send an error and stop the collection of diagnostics.