### PR TITLE
FISH-10835 Remote instances fail collecting logs due to NPE

### DIFF
--- a/src/main/java/fish/payara/extras/diagnostics/collection/CollectorService.java
+++ b/src/main/java/fish/payara/extras/diagnostics/collection/CollectorService.java
@@ -105,6 +105,7 @@ public class CollectorService {
     private Domain domain;
     private DomainUtil domainUtil;
     private final String domainName;
+    private Path logPath;
     private final ServiceLocator serviceLocator;
     private final Map<String, Object> parameterMap;
     private List<String> instanceList = new ArrayList<>();
@@ -480,7 +481,9 @@ public class CollectorService {
                 }
             }
 
-            Path logPath = Paths.get(domainUtil.getNodePaths().get(server.getNodeRef()).toString(), server.getName(), "logs");
+            if (instanceType.equals("CONFIG")){
+                logPath = Paths.get(domainUtil.getNodePaths().get(server.getNodeRef()).toString(), server.getName(), "logs");
+            }
 
             if (serverLog) {
                 if (!serverIsOn && instanceType.equals("CONFIG")) {


### PR DESCRIPTION
Remote instances got NPE when trying to create a log path which is meant for local instances.

I have created a variable to hold the log path and added an if statement to make sure it only gets populated if the `instanceType` is "CONFIG"