### PR TITLE
FISH-10826 Heap, Thread and JVM Report not collected by domain

### DIFF
--- a/src/main/java/fish/payara/extras/diagnostics/collection/CollectorService.java
+++ b/src/main/java/fish/payara/extras/diagnostics/collection/CollectorService.java
@@ -421,6 +421,18 @@ public class CollectorService {
                 }
             }
 
+            if (jvmReport) {
+                activeCollectors.add(new JVMCollector(environment, programOptions, "server", JvmCollectionType.JVM_REPORT, correctDomainRunning));
+            }
+
+            if (threadDump) {
+                activeCollectors.add(new JVMCollector(environment, programOptions, "server", JvmCollectionType.THREAD_DUMP, correctDomainRunning));
+            }
+
+            if (heapDump) {
+                activeCollectors.add(new HeapDumpCollector("server", programOptions, environment, correctDomainRunning));
+            }
+
             //adds folder for instance
             if (!instanceList.isEmpty()) {
                 addInstanceCollectors(activeCollectors, domainUtil.getStandaloneLocalInstances(), "");

--- a/src/main/java/fish/payara/extras/diagnostics/collection/CollectorService.java
+++ b/src/main/java/fish/payara/extras/diagnostics/collection/CollectorService.java
@@ -288,7 +288,7 @@ public class CollectorService {
                 LOGGER.info("Instance List " + this.instanceList);
             }
         } catch (Exception e) {
-            if (e.getMessage().contains("Is the server up?")) {
+            if (e.getMessage() != null && e.getMessage().contains("Is the server up?")) {
                 LOGGER.info("Server Offline! Only domain.xml and local server logs will be collected.");
                 LOGGER.info("Turn on Server to collect from instances!");
                 serverIsOn = false;

--- a/src/main/java/fish/payara/extras/diagnostics/collection/collectors/HeapDumpCollector.java
+++ b/src/main/java/fish/payara/extras/diagnostics/collection/collectors/HeapDumpCollector.java
@@ -79,6 +79,13 @@ public class HeapDumpCollector implements Collector {
     private ServiceLocator serviceLocator;
     private String dirSuffix;
 
+    public HeapDumpCollector(String target, ProgramOptions programOptions, Environment environment, boolean correctDomain) {
+        this.target = target;
+        this.programOptions = programOptions;
+        this.environment = environment;
+        this.correctDomain = correctDomain;
+    }
+
     public HeapDumpCollector(String target, ProgramOptions programOptions, Environment environment, String dirSuffix, CollectorService collectorService) {
         this.target = target;
         this.programOptions = programOptions;
@@ -110,13 +117,16 @@ public class HeapDumpCollector implements Collector {
             if (!Files.exists(outputPath)) {
                 Files.createDirectories(outputPath);
             }
-            if (targetType.equals("CONFIG")) {
-                //If it is local, uses destination folder as outputDir
-                parameterMap.add("outputDir", outputPath.toString());
+            if (targetType != null){
+                if (targetType.equals("CONFIG")) {
+                    //If it is local, uses destination folder as outputDir
+                    parameterMap.add("outputDir", outputPath.toString());
+                }
+                if (targetType.equals(SSH)) {
+                    parameterMap.add("outputDir", nodeInstallationDirectory);
+                }
             }
-            if (targetType.equals(SSH)) {
-                parameterMap.add("outputDir", nodeInstallationDirectory);
-            }
+            parameterMap.add("outputDir", outputPath.toString());
             programOptions.updateOptions(parameterMap);
             programOptions.setInteractive(false);
 
@@ -135,12 +145,14 @@ public class HeapDumpCollector implements Collector {
                 LOGGER.warning("Could not extract file name from result.");
             }
 
-            if (fileName != null && targetType.equals(SSH)) {
-                LOGGER.info("Downloading Heap Dump from remote host.");
-                String remoteFile = nodeInstallationDirectory+"/"+fileName;
-                downloadFileUsingSCP(remoteFile, outputPath.toString(), fileName);
-            } else if (targetType.equals(SSH)) {
-                LOGGER.warning("File name is null. Skipping file download");
+            if (targetType != null) {
+                if (fileName != null && targetType.equals(SSH)) {
+                    LOGGER.info("Downloading Heap Dump from remote host.");
+                    String remoteFile = nodeInstallationDirectory+"/"+fileName;
+                    downloadFileUsingSCP(remoteFile, outputPath.toString(), fileName);
+                } else if (targetType.equals(SSH)) {
+                    LOGGER.warning("File name is null. Skipping file download");
+                }
             }
 
             if (result.startsWith("Warning:") && result.contains("seems to be offline; command generate-heap-dump was not replicated to that instance")) {


### PR DESCRIPTION
I have added collection for these 3 for domain. I wrapped every `targetType` reference in an if `targetType != null` as if it is collecting for the domain, it would throw an error since the domain is not "CONFIG" or "SSH".