### PR TITLE
FISH-10872 Failing authentication should stop the collection

### DIFF
--- a/src/main/java/fish/payara/extras/diagnostics/collection/CollectorService.java
+++ b/src/main/java/fish/payara/extras/diagnostics/collection/CollectorService.java
@@ -101,6 +101,7 @@ public class CollectorService {
     private Boolean threadDump;
     private Boolean jvmReport;
     private Boolean heapDump;
+    private boolean isOkayToCollect = true;
     private boolean serverIsOn = true;
     private Domain domain;
     private DomainUtil domainUtil;
@@ -172,6 +173,9 @@ public class CollectorService {
             return 0;
         }
         getInstanceList();
+        if (!isOkayToCollect){
+            return 0;
+        }
         String instanceTargetPlaceholder = "";
 
         if (domain == null) {
@@ -293,6 +297,12 @@ public class CollectorService {
                 LOGGER.info("Server Offline! Only domain.xml and local server logs will be collected.");
                 LOGGER.info("Turn on Server to collect from instances!");
                 serverIsOn = false;
+            }
+            if (e.getMessage() != null && e.getMessage().contains("Authentication failed")) {
+                LOGGER.info(e.getMessage());
+                LOGGER.info("Cancelling collection");
+                isOkayToCollect = false;
+                return;
             }
             if (instanceList.isEmpty()) {
                 LOGGER.info("No instances found from remote command. Collecting local instances");


### PR DESCRIPTION
I have added an error message to appear if the authentication of the domain fails. This sets a variable to false and in turn returns 1 which causes the program to stop.

This displays the error message relating to the authentication and another log which shuts down the command.